### PR TITLE
Add option '--pull-request' to snf-ci

### DIFF
--- a/ci/snf-ci
+++ b/ci/snf-ci
@@ -40,6 +40,7 @@ Continuous Integration script for Synnefo.
 """
 
 import os
+import sys
 import utils
 from optparse import OptionParser
 
@@ -110,6 +111,8 @@ def main():  # pylint: disable=too-many-statements, too-many-branches
                       help="Specify the synnefo repo to use")
     parser.add_option("--synnefo-branch", dest="synnefo_branch", default=None,
                       help="Specify the synnefo branch to use")
+    parser.add_option("--pull-request", dest="pull_request", default=None,
+                      help="Test a Github pull request.")
     parser.add_option("-f", "--flavor", dest="flavor", default=None,
                       help="Flavor to use for the server."
                            " Supports both search by name (reg expression)"
@@ -178,9 +181,16 @@ def main():  # pylint: disable=too-many-statements, too-many-branches
                 parser.print_help()
                 print
                 print msg
-                return
+                sys.exit(1)
             else:
                 setattr(options, command, True)
+
+    if options.pull_request is not None:
+        if (options.synnefo_repo is not None or
+                options.synnefo_branch is not None):
+            print "ERROR: Options 'synnefo_repo' and/or 'synnefo_branch'" \
+                " cannot be given with 'pull_request'"
+            sys.exit(1)
 
     # ----------------------------------
     # Initialize SynnefoCi
@@ -205,7 +215,8 @@ def main():  # pylint: disable=too-many-statements, too-many-branches
         synnefo_ci.clone_repo(
             synnefo_repo=options.synnefo_repo,
             synnefo_branch=options.synnefo_branch,
-            local_repo=options.local_repo)
+            local_repo=options.local_repo,
+            pull_request=options.pull_request)
     if getattr(options, BUILD_SYNNEFO_CMD, False):
         synnefo_ci.build_packages()
         if options.fetch_packages:


### PR DESCRIPTION
This option gets a Github pull-request url (e.g. 'https://github.com/grnet/synnefo/pull/id') and runs the testsuite in a sophisticated way.

Sophisticated means that it will not just check the remote branch from which the pull request originated. Instead it will checkout the branch for which the pull request is indented (e.g. grnet:develop) and apply the pull request over it. This way it checks the pull request against the branch this pull request targets.
