### PR TITLE
cyclades: Unify arguments in management commands

### DIFF
--- a/snf-cyclades-app/synnefo/logic/management/commands/backend-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/backend-modify.py
@@ -42,7 +42,7 @@ HYPERVISORS = [h[0] for h in Backend.HYPERVISORS]
 
 class Command(BaseCommand):
     output_transaction = True
-    args = "<backend ID>"
+    args = "<backend_id>"
     help = "Modify a backend"
 
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/backend-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/backend-remove.py
@@ -43,6 +43,7 @@ non-deleted instances."""
 
 
 class Command(BaseCommand):
+    args = "<backend_id>"
     help = HELP_MSG
 
     def handle(self, *args, **options):

--- a/snf-cyclades-app/synnefo/logic/management/commands/flavor-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/flavor-modify.py
@@ -43,7 +43,7 @@ log = getLogger(__name__)
 
 
 class Command(BaseCommand):
-    args = "<flavor id>"
+    args = "<flavor_id>"
     help = "Modify a flavor"
 
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-attach.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-attach.py
@@ -39,6 +39,7 @@ from synnefo.logic import servers
 
 
 class Command(BaseCommand):
+    args = "<floating_ip_id>"
     help = "Attach a floating IP to a VM or router"
 
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-detach.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-detach.py
@@ -39,6 +39,7 @@ from synnefo.logic import servers
 
 
 class Command(BaseCommand):
+    args = "<floating_ip_id>"
     help = "Detach a floating IP from a VM or router"
 
     @common.convert_api_faults

--- a/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/floating-ip-remove.py
@@ -41,7 +41,7 @@ from synnefo.logic import ips
 
 
 class Command(RemoveCommand):
-    args = "<Floating-IP ID> [<Floating-IP ID> ...]"
+    args = "<floating_ip_id> [<floating_ip_id> ...]"
     help = "Release a floating IP"
 
     @common.convert_api_faults

--- a/snf-cyclades-app/synnefo/logic/management/commands/network-inspect.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/network-inspect.py
@@ -39,7 +39,7 @@ from synnefo.management import pprint, common
 
 class Command(BaseCommand):
     help = "Inspect a network on DB and Ganeti."
-    args = "<Network ID>"
+    args = "<network_id>"
 
     option_list = BaseCommand.option_list + (
         make_option(

--- a/snf-cyclades-app/synnefo/logic/management/commands/network-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/network-modify.py
@@ -43,7 +43,7 @@ from django.db import transaction
 
 
 class Command(BaseCommand):
-    args = "<Network ID>"
+    args = "<network_id>"
     help = "Modify a network."
 
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/network-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/network-remove.py
@@ -37,7 +37,7 @@ from synnefo.management import common
 
 class Command(RemoveCommand):
     can_import_settings = True
-    args = "<Network ID> [<Network ID> ...]"
+    args = "<network_id> [<network_id> ...]"
     help = "Remove a network from the Database, and Ganeti"
 
     @common.convert_api_faults

--- a/snf-cyclades-app/synnefo/logic/management/commands/pool-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/pool-modify.py
@@ -1,4 +1,4 @@
-# Copyright 2012 GRNET S.A. All rights reserved.
+# Copyright 2012-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -39,7 +39,7 @@ POOL_CHOICES = ['bridge', 'mac-prefix']
 
 
 class Command(BaseCommand):
-    args = "<pool ID>"
+    args = "<pool_id>"
     help = "Modify a pool"
     output_transaction = True
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/pool-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/pool-remove.py
@@ -1,4 +1,4 @@
-# Copyright 2012 GRNET S.A. All rights reserved.
+# Copyright 2012-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -42,7 +42,7 @@ POOL_CHOICES = ['bridge', 'mac-prefix']
 
 class Command(RemoveCommand):
     help = "Remove a pool."
-    args = "<pool ID>"
+    args = "<pool_id>"
     output_transaction = True
     command_option_list = RemoveCommand.command_option_list + (
         make_option("--type", dest="type",

--- a/snf-cyclades-app/synnefo/logic/management/commands/pool-show.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/pool-show.py
@@ -1,4 +1,4 @@
-# Copyright 2012 GRNET S.A. All rights reserved.
+# Copyright 2012-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -41,7 +41,7 @@ POOL_CHOICES = ['bridge', 'mac-prefix']
 
 
 class Command(BaseCommand):
-    args = "<pool ID>"
+    args = "<pool_id>"
     help = "Show a pool"
     output_transaction = True
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/port-inspect.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/port-inspect.py
@@ -40,7 +40,7 @@ from synnefo.management import pprint, common
 
 class Command(BaseCommand):
     help = "Inspect a port on DB and Ganeti"
-    args = "<port ID>"
+    args = "<port_id>"
 
     option_list = BaseCommand.option_list + (
         make_option(

--- a/snf-cyclades-app/synnefo/logic/management/commands/port-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/port-remove.py
@@ -38,7 +38,7 @@ from snf_django.management.commands import RemoveCommand
 
 class Command(RemoveCommand):
     can_import_settings = True
-    args = "<Port ID> [<Port ID> ...]"
+    args = "<port_id> [<port_id> ...]"
     help = "Remove a port from the Database and from the VMs attached to"
     command_option_list = RemoveCommand.command_option_list + (
         make_option(

--- a/snf-cyclades-app/synnefo/logic/management/commands/queue-inspect.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/queue-inspect.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2012 GRNET S.A. All rights reserved.
+# Copyright 2011-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ from synnefo.lib.amqp import AMQPClient
 
 
 class Command(BaseCommand):
-    args = "<queue name>"
+    args = "<queue_name>"
     help = "Inspect the messages of a queue. Close all other clients in "\
            "order to be able to inspect unacknowledged messages."
 

--- a/snf-cyclades-app/synnefo/logic/management/commands/server-inspect.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/server-inspect.py
@@ -40,7 +40,7 @@ from synnefo.management import pprint
 
 class Command(BaseCommand):
     help = "Inspect a server on DB and Ganeti"
-    args = "<server ID>"
+    args = "<server_id>"
 
     option_list = BaseCommand.option_list + (
         make_option(

--- a/snf-cyclades-app/synnefo/logic/management/commands/server-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/server-modify.py
@@ -45,7 +45,7 @@ ACTIONS = ["start", "stop", "reboot_hard", "reboot_soft"]
 
 
 class Command(BaseCommand):
-    args = "<server ID>"
+    args = "<server_id>"
     help = "Modify a server."
 
     option_list = BaseCommand.option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/server-remove.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/server-remove.py
@@ -43,7 +43,7 @@ from snf_django.lib.api import faults
 
 
 class Command(RemoveCommand):
-    args = "<Server ID> [<Server ID> ...]"
+    args = "<server_id> [<server_id> ...]"
     help = "Remove a server by deleting the instance from the Ganeti backend."
 
     command_option_list = RemoveCommand.command_option_list + (

--- a/snf-cyclades-app/synnefo/logic/management/commands/server-show.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/server-show.py
@@ -42,7 +42,7 @@ from snf_django.management import utils
 
 
 class Command(SynnefoCommand):
-    args = "<server ID>"
+    args = "<server_id>"
     help = "Show server info"
 
     def handle(self, *args, **options):

--- a/snf-cyclades-app/synnefo/logic/management/commands/subnet-inspect.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/subnet-inspect.py
@@ -1,4 +1,4 @@
-# Copyright 2013 GRNET S.A. All rights reserved.
+# Copyright 2013-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -39,7 +39,7 @@ from synnefo.management import pprint, common
 
 class Command(BaseCommand):
     help = "Inspect a subnet on DB and Ganeti."
-    args = "<Subnet ID>"
+    args = "<subnet_id>"
     option_list = BaseCommand.option_list
 
     def handle(self, *args, **options):

--- a/snf-cyclades-app/synnefo/logic/management/commands/subnet-modify.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/subnet-modify.py
@@ -47,7 +47,7 @@ be updated.
 
 class Command(BaseCommand):
     help = "Update a Subnet." + HELP_MSG
-    args = "<Subnet ID>"
+    args = "<subnet_id>"
     option_list = BaseCommand.option_list + (
         make_option("--name", dest="name",
                     help="The new subnet name."),


### PR DESCRIPTION
Unify the string listing that is used to describe the arguments that are
accepted by snf-manage commands, and are displayed in the 'usage' of the
commands' help message. Also, add the argument in some commands that it
was missing.
