### PR TITLE
burnin: Fix 'project_id' param in 'create_floatingip'

### DIFF
--- a/snf-tools/synnefo_tools/burnin/cyclades_common.py
+++ b/snf-tools/synnefo_tools/burnin/cyclades_common.py
@@ -517,7 +517,7 @@ class CycladesTests(BurninTests):
                       pub_net['id'])
             try:
                 fip = self.clients.network.create_floatingip(
-                    pub_net['id'], project=project_id)
+                    pub_net['id'], project_id=project_id)
             except ClientError as err:
                 self.warning("%s: %s", err.message, err.details)
                 continue


### PR DESCRIPTION
Until now, burnin was using a 'feature' version of kamaki
where the 'create_floatingip' method had a 'project' parameter.
This parameter was renamed to 'project_id' for uniformity with the
other kamaki methods.

These changes have been merged to 'develop' branch of kamaki and the API
is not expected to be changed again. This patch changes the way burnin
invokes 'create_floatingip' to use the 'project_id' parameter instead of
the 'project' one.
