### PR TITLE
burnin: Filter flavors based on 'SNF:allow_create'

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -431,13 +431,23 @@ class SynnefoCI(object):
 
         Search by name (reg expression) or by id
         """
+        def _is_true(value):
+            """Boolean or string value that represents a bool"""
+            if isinstance(value, bool):
+                return value
+            elif isinstance(value, str):
+                return value in ["True", "true"]
+            else:
+                self.logger.error("Unrecognized boolean value %s" % value)
+                return False
+
         # Get a list of flavors from config file
         flavors = self.config.get('Deployment', 'flavors').split(",")
         if flavor is not None:
             # If we have a flavor_name to use, add it to our list
             flavors.insert(0, flavor)
 
-        list_flavors = self.compute_client.list_flavors()
+        list_flavors = self.compute_client.list_flavors(detail=True)
         for flv in flavors:
             flv_type, flv_value = parse_typed_option(option="flavor",
                                                      value=flv)
@@ -460,6 +470,8 @@ class SynnefoCI(object):
                 self.logger.error("Unrecognized flavor type %s" % flv_type)
 
             # Check if we found one
+            list_flvs = [f for f in list_flvs
+                         if _is_true(f['SNF:allow_create'])]
             if list_flvs:
                 self.logger.debug("Will use \"%s\" with id \"%s\""
                                   % (_green(list_flvs[0]['name']),

--- a/snf-tools/synnefo_tools/burnin/common.py
+++ b/snf-tools/synnefo_tools/burnin/common.py
@@ -1,4 +1,4 @@
-# Copyright 2013 GRNET S.A. All rights reserved.
+# Copyright 2013-2014 GRNET S.A. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or
 # without modification, are permitted provided that the following
@@ -397,6 +397,16 @@ class BurninTests(unittest.TestCase):
         matching this patterns will be returned.
 
         """
+        def _is_true(value):
+            """Boolean or string value that represents a bool"""
+            if isinstance(value, bool):
+                return value
+            elif isinstance(value, str):
+                return value in ["True", "true"]
+            else:
+                self.warning("Unrecognized boolean value %s", value)
+                return False
+
         if flavors is None:
             flavors = self._get_list_of_flavors(detail=True)
 
@@ -424,6 +434,10 @@ class BurninTests(unittest.TestCase):
                     [f for f in flavors if str(f['id']) == flv_value]
             else:
                 self.error("Unrecognized flavor type %s", flv_type)
+
+            # Get only flavors that are allowed to create a machine
+            filtered_flvs = [f for f in filtered_flvs
+                             if _is_true(f['SNF:allow_create'])]
 
             # Append and continue
             ret_flavors.extend(filtered_flvs)


### PR DESCRIPTION
Filter out flavors that are not allowed to create a machine.
Update snf-ci to support the same functionality.
