### PR TITLE
snf-deploy: Disable direct I/O in Archipelago

### DIFF
--- a/snf-deploy/files/etc/archipelago/archipelago.conf
+++ b/snf-deploy/files/etc/archipelago/archipelago.conf
@@ -72,7 +72,7 @@ nr_ops=64
 nr_threads=64
 archip_dir=/srv/archip/blocks
 fdcache=512
-direct=True
+direct=False
 
 [blockerm]
 type=file_blocker
@@ -83,7 +83,7 @@ nr_ops=64
 nr_threads=64
 archip_dir=/srv/archip/maps
 fdcache=512
-direct=True
+direct=False
 
 # mapperd specific options:
 #


### PR DESCRIPTION
When writing Pithos+ mapfiles with direct I/O enabled Archipelago takes
care to use properly aligned and sized I/O based on the basic block unit,
which is 512 bytes. The result is to pad the file with zeros and finally
produce the wrong mapfile.
