### PR TITLE
snf_django: Fix string formatting

### DIFF
--- a/snf-django-lib/snf_django/management/commands/__init__.py
+++ b/snf-django-lib/snf_django/management/commands/__init__.py
@@ -190,9 +190,9 @@ class SynnefoCommand(BaseCommand):
                 self.stdout.logger = logger
                 self.stderr.logger = logger
             except OSError as err:
-                msg = "Could not open file %s for write: %s\n" + \
-                    "Will not log this command's output\n" \
-                    % (filename, err)
+                msg = ("Could not open file %s for write: %s\n"
+                       "Will not log this command's output\n") % (
+                    filename, err)
                 sys.stderr.write(msg)
 
         argv = [utils.smart_locale_unicode(a) for a in argv]


### PR DESCRIPTION
Format arguments were applied to the last part of the string which contained
no % format operators. Concat strings before applying format.

@iliastsi for review
