### PR TITLE
cyclades: Allow use of floating IPs from drained networks

### DIFF
--- a/snf-cyclades-app/synnefo/logic/servers.py
+++ b/snf-cyclades-app/synnefo/logic/servers.py
@@ -456,9 +456,6 @@ def _create_port(userid, network, machine=None, use_ipaddress=None,
     elif network.action == "DESTROY":
         msg = "Cannot create port. Network %s is being deleted."
         raise faults.Conflict(msg % network.id)
-    elif network.drained:
-        raise faults.Conflict("Cannot create port while network %s is in"
-                              " 'SNF:DRAINED' status" % network.id)
 
     utils.check_name_length(name, NetworkInterface.NETWORK_IFACE_NAME_LENGTH,
                             "Port name is too long")
@@ -471,6 +468,10 @@ def _create_port(userid, network, machine=None, use_ipaddress=None,
             msg = "IP Address %s does not belong to network %s"
             raise faults.Conflict(msg % (ipaddress.address, network.id))
     else:
+        # Do not allow allocation of new IPs if the network is drained
+        if network.drained:
+            raise faults.Conflict("Cannot create port while network %s is in"
+                                  " 'SNF:DRAINED' status" % network.id)
         # If network has IPv4 subnets, try to allocate the address that the
         # the user specified or a random one.
         if network.subnets.filter(ipversion=4).exists():


### PR DESCRIPTION
This commit makes possible to create a port to a drained network when
using a floating IP that has been already allocated. The 'drained' flag
should only affect the allocation of new IPs and not the use of existing
ones.
