### PR TITLE
snf_django: Fix unicode error in proxy requests

### DIFF
--- a/snf-django-lib/snf_django/lib/api/proxy/__init__.py
+++ b/snf-django-lib/snf_django/lib/api/proxy/__init__.py
@@ -32,6 +32,7 @@
 # or implied, of GRNET S.A.
 
 from django.http import HttpResponse, HttpResponseRedirect
+from django.utils.encoding import smart_str
 
 from objpool.http import PooledHTTPConnection
 
@@ -84,9 +85,9 @@ def proxy(request, proxy_base=None, target_base=None, redirect=False):
         headers.pop(k, None)
 
     kwargs['headers'] = headers
-    kwargs['body'] = request.POST.urlencode()
+    kwargs['body'] = request.body
 
-    path = request.path.lstrip('/')
+    path = smart_str(request.path, encoding='utf-8').lstrip('/')
     if not path.startswith(proxy_base):
         m = "request path '{0}' does not start with proxy_base '{1}'"
         m = m.format(path, proxy_base)


### PR DESCRIPTION
Pithos and Cyclades services need to proxy Astakos API calls for enabling
the web clients to access them.

Proxy requests containing non ASCII characters used to fail.

The reason was that the proxy tried to make a request using the original
request path.
However Django forces the request path to be unicode.
Therefore, the httplib used to fail because it tried to concatenate unicode
and bytestrings.

This fix changes the original implementation and from now on it sends
the requested URL encoded in UTF-8.
