### PR TITLE
cyclades: Remove verbose output from stats command

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,19 @@ Unified Changelog file for Synnefo versions >= 0.13
 Since v0.13 most of the Synnefo components have been merged into a single
 repository and have aligned versions.
 
+.. _Changelog-0.15.2:
+
+v0.15.2
+=======
+
+Released: UNRELEASED
+
+Cyclades
+--------
+
+* Fix small issue in the 'stats-cyclades' command arising when Ganeti cannot
+  communicate with a node.
+
 .. _Changelog-0.15.1:
 
 v0.15.1

--- a/snf-cyclades-app/synnefo/admin/stats.py
+++ b/snf-cyclades-app/synnefo/admin/stats.py
@@ -88,7 +88,7 @@ def _get_cluster_stats(bend):
             "offline": node["offline"],
             "vm_capable": node["vm_capable"],
             "instances": node["pinst_cnt"],
-            "cpu": node["ctotal"],
+            "cpu": (node["ctotal"] or 0),
             "ram": {
                 "total": (node["mtotal"] or 0) << 20,
                 "free": (node["mfree"] or 0) << 20

--- a/snf-cyclades-app/synnefo/logic/management/commands/stats-cyclades.py
+++ b/snf-cyclades-app/synnefo/logic/management/commands/stats-cyclades.py
@@ -251,7 +251,6 @@ def pprint_clusters(clusters, stdout, detail=True):
                    "CPUs", "RAM (used/total)", "Disk (used/total)")
         pprint_table(stdout, node_table, headers, separator=" | ",
                      title="Statistics per node for backend %s" % cluster_name)
-        stdout.write("\n")
 
     total_table = (
         ("Backend", t_backend_cnt),
@@ -280,8 +279,11 @@ def pprint_clusters(clusters, stdout, detail=True):
         ("V/P total disk", ("%.2f%%" % (100 * t_vdisk / t_dtotal)
                             if t_dtotal != 0 else "-")),
     )
-    pprint_table(stdout, total_table, headers=None, separator=" | ",
-                 title="Statistics for all backends")
+
+    if len(clusters) > 1:
+        stdout.write("\n")
+        pprint_table(stdout, total_table, headers=None, separator=" | ",
+                     title="Statistics for all backends")
 
 
 def pprint_servers(servers, stdout):


### PR DESCRIPTION
Do not print aggregate statistics for all Ganeti backends in case there
exists only one backend. Also, fix a small issue where Ganeti will
return a 'None' value for 'csockets' attribute when it cannot
communicate with a Ganeti node.
