### PR TITLE
docs: Update installation guides

### DIFF
--- a/docs/install-guide-centos.rst
+++ b/docs/install-guide-centos.rst
@@ -2263,7 +2263,7 @@ skipped.
 
 .. code-block:: console
 
-   node1 # snf-manage quota --sync
+   node1 # snf-manage quota-verify --sync
    node1 # snf-manage reconcile-resources-astakos --fix
    node2 # snf-manage reconcile-resources-pithos --fix
    node1 # snf-manage reconcile-resources-cyclades --fix

--- a/docs/install-guide-debian.rst
+++ b/docs/install-guide-debian.rst
@@ -2291,7 +2291,7 @@ skipped.
 
 .. code-block:: console
 
-   node1 # snf-manage quota --sync
+   node1 # snf-manage quota-verify --sync
    node1 # snf-manage reconcile-resources-astakos --fix
    node2 # snf-manage reconcile-resources-pithos --fix
    node1 # snf-manage reconcile-resources-cyclades --fix


### PR DESCRIPTION
This patch set:
- Updates installation guides to use `snf-manage quota-verify --sync` instead of `snf-manage quota --sync`
- Updates CentOS installation guide
  - Add a note to disable `SELinux`
  - Add a note that `hotplug` won't work with qemu < 1.0
  - Fix a minor typo
