### PR TITLE
gtools: Fix collectd plugin wrt netstats

### DIFF
--- a/snf-cyclades-gtools/collectd/plugins/ganeti-netstats.py
+++ b/snf-cyclades-gtools/collectd/plugins/ganeti-netstats.py
@@ -26,7 +26,10 @@ def netstats(data=None):
         hostname = os.path.basename(dir)
 
         for nic in glob(os.path.join(dir, "*")):
-            idx = int(os.path.basename(nic))
+            try:
+                idx = int(os.path.basename(nic))
+            except ValueError:
+                continue
             with open(nic) as nicfile:
                 try:
                     iface = nicfile.readline().strip()


### PR DESCRIPTION
Ganeti with ifdown support adds a new file per NIC (with
name it's UUID) under /var/run/ganeti/kvm-hypervisor/nic/<vm>/.
Let ganeti-netstats.py collectd plugin be aware of this change.

Signed-off-by: Dimitris Aragiorgis dimara@grnet.gr
