### PR TITLE
Fix Internal Server Errors in not allowed requests

### DIFF
--- a/snf-cyclades-app/synnefo/api/ports.py
+++ b/snf-cyclades-app/synnefo/api/ports.py
@@ -63,7 +63,8 @@ def demux(request):
     elif request.method == 'POST':
         return create_port(request)
     else:
-        return api.api_method_not_allowed(request)
+        return api.api_method_not_allowed(request, allowed_methods=['GET',
+                                                                    'POST'])
 
 
 def port_demux(request, port_id):
@@ -75,7 +76,9 @@ def port_demux(request, port_id):
     elif request.method == 'PUT':
         return update_port(request, port_id)
     else:
-        return api.api_method_not_allowed(request)
+        return api.api_method_not_allowed(request, allowed_methods=['GET',
+                                                                    'DELETE',
+                                                                    'PUT'])
 
 
 @api.api_method(http_method='GET', user_required=True, logger=log)

--- a/snf-cyclades-app/synnefo/api/subnets.py
+++ b/snf-cyclades-app/synnefo/api/subnets.py
@@ -62,7 +62,8 @@ def demux(request):
     elif request.method == 'POST':
         return create_subnet(request)
     else:
-        return api.api_method_not_allowed(request)
+        return api.api_method_not_allowed(request, allowed_methods=['GET',
+                                                                    'POST'])
 
 
 def subnet_demux(request, sub_id):
@@ -73,7 +74,9 @@ def subnet_demux(request, sub_id):
     elif request.method == 'PUT':
         return update_subnet(request, sub_id)
     else:
-        return api.api_method_not_allowed(request)
+        return api.api_method_not_allowed(request, allowed_methods=['GET',
+                                                                    'DELETE',
+                                                                    'PUT'])
 
 
 @api.api_method(http_method='GET', user_required=True, logger=log)

--- a/snf-pithos-app/pithos/api/public.py
+++ b/snf-pithos-app/pithos/api/public.py
@@ -56,7 +56,9 @@ def public_demux(request, v_public):
     elif request.method == 'GET':
         return public_read(request, v_public)
     else:
-        return api.api_method_not_allowed(request)
+        return api.api_method_not_allowed(request,
+                                          allowed_methods=['HEAD',
+                                                           'GET'])
 
 
 @api_method(http_method="HEAD", token_required=False, user_required=False,

--- a/snf-pithos-app/pithos/api/test/public.py
+++ b/snf-pithos-app/pithos/api/test/public.py
@@ -74,6 +74,26 @@ class TestPublic(PithosAPITest):
 
         p = re.compile('(attachment|inline); filename="(.+)"')
 
+        r = self.delete(public)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(sorted(r['Allow'].split(',')),  ['GET', 'HEAD'])
+
+        r = self.post(public)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(sorted(r['Allow'].split(',')),  ['GET', 'HEAD'])
+
+        r = self.put(public)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(sorted(r['Allow'].split(',')),  ['GET', 'HEAD'])
+
+        r = self.copy(public)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(sorted(r['Allow'].split(',')),  ['GET', 'HEAD'])
+
+        r = self.move(public)
+        self.assertEqual(r.status_code, 405)
+        self.assertEqual(sorted(r['Allow'].split(',')),  ['GET', 'HEAD'])
+
         r = self.get(public, user='user2', token=None)
         self.assertEqual(r.status_code, 200)
         self.assertTrue('X-Object-Public' not in r)


### PR DESCRIPTION
The 'api_method_not_allowed' method requires two arguments:
the request and the allowed methods to be listed in the Allow header.
However, the allowed_methods argument was missing from some calls,
resulting to unexpected failures.
This commit fixes these issues.
