### PR TITLE
pithos: Fix tests

### DIFF
--- a/snf-pithos-app/pithos/api/test/objects.py
+++ b/snf-pithos-app/pithos/api/test/objects.py
@@ -1801,7 +1801,7 @@ class ObjectPost(PithosAPITest):
         block_size = pithos_settings.BACKEND_BLOCK_SIZE
         oname, odata = self.upload_object(
             self.container, length=random.randint(
-                block_size + 1, 2 * block_size))[:2]
+                block_size + 2, 2 * block_size))[:2]
 
         length = len(odata)
         first_byte_pos = random.randint(1, block_size)
@@ -1935,7 +1935,7 @@ class ObjectPost(PithosAPITest):
         r = self.put(url, data=initial_data)
         self.assertEqual(r.status_code, 201)
 
-        offset = random.randint(0, source_length - 1)
+        offset = random.randint(0, source_length - 2)
         upto = random.randint(offset, source_length - 1)
         r = self.post(url,
                       HTTP_CONTENT_RANGE='bytes %s-%s/*' % (offset, upto),


### PR DESCRIPTION
Fix tests challenging partial content update that used to fail with ValueError: empty range for randrange().
