### PR TITLE
debian: Install all snf-deploy scripts

### DIFF
--- a/debian/snf-deploy.install
+++ b/debian/snf-deploy.install
@@ -1,3 +1,3 @@
-snf-deploy/scripts/ifup usr/lib/snf-deploy
+snf-deploy/scripts/* usr/lib/snf-deploy
 snf-deploy/conf/* etc/snf-deploy
 snf-deploy/files/* var/lib/snf-deploy/files


### PR DESCRIPTION
Install scripts found in snf-deploy/scripts under
usr/lib/snf-deploy.

Signed-off-by: Dimitris Aragiorgis dimara@grnet.gr
