### PR TITLE
docs: Typo fixes

### DIFF
--- a/docs/install-guide-centos.rst
+++ b/docs/install-guide-centos.rst
@@ -2095,7 +2095,7 @@ You can see everything has been setup correctly by running:
 
 Enable the new backend by running:
 
-.. code-block::
+.. code-block:: console
 
    $ snf-manage backend-modify --drained False 1
 

--- a/docs/install-guide-debian.rst
+++ b/docs/install-guide-debian.rst
@@ -2123,7 +2123,7 @@ You can see everything has been setup correctly by running:
 
 Enable the new backend by running:
 
-.. code-block::
+.. code-block:: console
 
    $ snf-manage backend-modify --drained False 1
 


### PR DESCRIPTION
Minor typo fixes in Debian and CentOS installation guides.
