### PR TITLE
cyclades: Add option to disable snapshots API

### DIFF
--- a/snf-cyclades-app/conf/20-snf-cyclades-app-api.conf
+++ b/snf-cyclades-app/conf/20-snf-cyclades-app-api.conf
@@ -16,6 +16,11 @@
 ## Astakos groups that have access to '/admin' views.
 #ADMIN_STATS_PERMITTED_GROUPS = ["admin-stats"]
 #
+## Enable/Disable the snapshots feature altogether at the API level.
+## If set to False, Cyclades will not expose the '/snapshots' API URL
+## of the ‘volume’ app.
+#CYCLADES_SNAPSHOTS_ENABLED = False
+#
 ##
 ## Network Configuration
 ##

--- a/snf-cyclades-app/synnefo/api/servers.py
+++ b/snf-cyclades-app/synnefo/api/servers.py
@@ -49,11 +49,15 @@ urlpatterns = patterns(
 )
 
 VOLUME_SOURCE_TYPES = [
-    "snapshot",
     "image",
     "volume",
     "blank"
 ]
+
+if settings.CYCLADES_SNAPSHOTS_ENABLED:
+    # If snapshots are enabled, add 'snapshot' to the list of allowed sources
+    # for a new block device.
+    VOLUME_SOURCE_TYPES.append("snapshot")
 
 
 def demux(request):

--- a/snf-cyclades-app/synnefo/app_settings/default/api.py
+++ b/snf-cyclades-app/synnefo/app_settings/default/api.py
@@ -16,6 +16,11 @@ POLL_LIMIT = 3600
 # Astakos groups that have access to '/admin' views.
 ADMIN_STATS_PERMITTED_GROUPS = ["admin-stats"]
 
+# Enable/Disable the snapshots feature altogether at the API level.
+# If set to False, Cyclades will not expose the '/snapshots' API URL
+# of the ‘volume’ app.
+CYCLADES_SNAPSHOTS_ENABLED = False
+
 #
 # Network Configuration
 #

--- a/snf-cyclades-app/synnefo/volume/urls.py
+++ b/snf-cyclades-app/synnefo/volume/urls.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from django.conf import settings
 from django.conf.urls.defaults import patterns, include
 from django.http import HttpResponseNotAllowed
 from snf_django.lib import api
@@ -130,15 +131,21 @@ volume_v2_patterns = patterns(
     (r'^volumes/(\d+)/metadata/?(?:.json)?$', volume_metadata_demux),
     (r'^volumes/(\d+)/metadata/(.+)(?:.json)?$', volume_metadata_item_demux),
     (r'^volumes/(\d+)/action(?:.json|.xml)?$', volume_action_demux),
-    (r'^snapshots/?(?:.json)?$', snapshot_demux),
-    (r'^snapshots/detail$', views.list_snapshots, {'detail': True}),
-    (r'^snapshots/([\w-]+)(?:.json)?$', snapshot_item_demux),
-    (r'^snapshots/([\w-]+)/metadata/?(?:.json)?$', snapshot_metadata_demux),
-    (r'^snapshots/([\w-]+)/metadata/(.+)(?:.json)?$',
-        snapshot_metadata_item_demux),
     (r'^types/?(?:.json)?$', views.list_volume_types),
     (r'^types/(\d+)(?:.json)?$', views.get_volume_type),
 )
+
+if settings.CYCLADES_SNAPSHOTS_ENABLED:
+    volume_v2_patterns += patterns(
+        '',
+        (r'^snapshots/?(?:.json)?$', snapshot_demux),
+        (r'^snapshots/detail$', views.list_snapshots, {'detail': True}),
+        (r'^snapshots/([\w-]+)(?:.json)?$', snapshot_item_demux),
+        (r'^snapshots/([\w-]+)/metadata/?(?:.json)?$',
+            snapshot_metadata_demux),
+        (r'^snapshots/([\w-]+)/metadata/(.+)(?:.json)?$',
+            snapshot_metadata_item_demux),
+    )
 
 urlpatterns = patterns(
     '',

--- a/snf-cyclades-app/synnefo/volume/views.py
+++ b/snf-cyclades-app/synnefo/volume/views.py
@@ -19,6 +19,7 @@ from django.db import transaction
 from django.http import HttpResponse
 from django.utils import simplejson as json
 from django.utils.encoding import smart_unicode
+from django.conf import settings
 
 from dateutil.parser import parse as date_parse
 
@@ -123,9 +124,14 @@ def create_volume(request):
     # Id of the volume to clone from
     source_volume_id = utils.get_attribute(vol_dict, "source_volid",
                                            required=False)
+
     # Id of the snapshot to create the volume from
     source_snapshot_id = utils.get_attribute(vol_dict, "snapshot_id",
                                              required=False)
+    if source_snapshot_id and not settings.CYCLADES_SNAPSHOTS_ENABLED:
+        raise faults.NotImplemented("Making a clone from a snapshot is not"
+                                    " implemented")
+
     # Reference to an Image stored in Glance
     source_image_id = utils.get_attribute(vol_dict, "imageRef", required=False)
 


### PR DESCRIPTION
Add 'CYCLADES_SNAPSHOTS_ENABLED' setting to denote whether Cyclades
will expose the '/snapshots' API URL of the 'volume' app.
In case this setting is set to False:
- we disable the '/snapshots' API URL
- return 501 if the 'source_snapshot_id' attribute is used in a request
  for a new volume
- Remove 'snapshot' from the supported sources of a new volume in the
  create server request

Note: Creation and handling of snapshots can still be performed via
'snf-manage' commands. The setting affects only the exposed API.
