### PR TITLE
webproject: Remove wrong entries from package manifest

### DIFF
--- a/snf-webproject/MANIFEST.in
+++ b/snf-webproject/MANIFEST.in
@@ -1,6 +1,4 @@
 recursive-include synnefo *.json *.html *.json *.xml *.txt
-recursive-include synnefo/admin/static *
-recursive-include synnefo/ui/static *
 recursive-include docs *.rst
 recursive-include extras *
 


### PR DESCRIPTION
Two entries were mistakenly copied from the cyclades manifest.
