### PR TITLE
astakos: Add cyclades_volume in service script

### DIFF
--- a/snf-astakos-app/astakos/scripts/snf_service_export.py
+++ b/snf-astakos-app/astakos/scripts/snf_service_export.py
@@ -231,6 +231,18 @@ cyclades_services = {
         ],
         'resources': {},
     },
+
+    'cyclades_volume': {
+        'type': 'volume',
+        'component': 'cyclades',
+        'prefix': 'volume',
+        'public': True,
+        'endpoints': [
+            {'versionId': 'v2.0',
+             'publicURL': None},
+        ],
+        'resources': {},
+    },
 }
 
 pithos_services = {


### PR DESCRIPTION
Add the missing cyclades_volume definition in the service registration
script.
