### PR TITLE
pithos: Fix deadlock caused by erroneous check

### DIFF
--- a/snf-pithos-backend/pithos/backends/lib/sqlalchemy/node.py
+++ b/snf-pithos-backend/pithos/backends/lib/sqlalchemy/node.py
@@ -640,7 +640,7 @@ class Node(DBWorker):
         while True:
             if node == ROOTNODE:
                 break
-            if recursion_depth and recursion_depth <= i:
+            if recursion_depth is not None and recursion_depth <= i:
                 break
             props = self.node_get_properties(node)
             if props is None:


### PR DESCRIPTION
To achieve atomicity we lock the container path.
However, the write operations update the statistics for the ancestor
nodes (container/account).
Therefore, the backend restricts the recursion up to the container
level.

However, the specific condition check would be evaluated to False
if `recursion_depth` was 0.
