### PR TITLE
pithos: Restore XML input in uploads using hashmaps

### DIFF
--- a/docs/object-api-guide.rst
+++ b/docs/object-api-guide.rst
@@ -27,6 +27,7 @@ Document Revisions
 =========================  ================================
 Revision                   Description
 =========================  ================================
+0.16 (Jul 11, 2014)        Restore uploads using hashmaps: accept XML input.
 0.15 (Apr 03, 2014)        Allow only JSON format in uploads using hashmaps.
 0.15 (Feb 01, 2014)        Optionally enforce a specific content disposition type.
 0.14 (Jun 18, 2013)        Forbidden response for public listing by non path owners.
@@ -941,15 +942,14 @@ X-Object-Meta-*       Optional user defined metadata
 ======================  ===================================
 Request Parameter Name  Value
 ======================  ===================================
-format                  Optional extended request/conflict response type (obsolete: always ``json`` is assumed)
+format                  Optional extended request/conflict response type (can be ``json`` or ``xml``)
 hashmap                 Optional hashmap provided instead of data (no value parameter)
 delimiter               Optional copy/move objects starting with object's path and delimiter (to be used with X-Copy-From/X-Move-From)
 ======================  ===================================
 
-The request is the object's data (or part of it), except if a hashmap is provided (using the ``hashmap`` parameter). If using a hashmap and all different parts are already stored in the server, the object is created. Otherwise the server returns Conflict (409) with the list of the missing parts in JSON.
+The request is the object's data (or part of it), except if a hashmap is provided (using ``hashmap`` and ``format`` parameters). If using a hashmap and all different parts are stored in the server, the object is created. Otherwise the server returns Conflict (409) with the list of the missing parts (in simple text format, with one hash per line, or in JSON/XML - depending on the ``format`` parameter).
 
-Hashmaps should be formatted in JSON as outlined in ``GET``.
-
+Hashmaps should be formatted as outlined in ``GET``.
 
 ==========================  ===============================
 Reply Header Name           Value

--- a/snf-pithos-app/pithos/api/functions.py
+++ b/snf-pithos-app/pithos/api/functions.py
@@ -13,6 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from lxml import etree
+
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.utils import simplejson as json
@@ -980,7 +982,7 @@ def _object_read(request, v_account, v_container, v_object):
     return object_data_response(request, sizes, hashmaps, meta)
 
 
-@api_method('PUT', format_allowed=False, user_required=True, logger=logger,
+@api_method('PUT', format_allowed=True, user_required=True, logger=logger,
             lock_container_path=True)
 def object_write(request, v_account, v_container, v_object):
     # Normal Response Codes: 201
@@ -1059,17 +1061,35 @@ def object_write(request, v_account, v_container, v_object):
         raise faults.LengthRequired('Missing Content-Type header')
 
     if 'hashmap' in request.GET:
+        if request.serialization not in ('json', 'xml'):
+            raise faults.BadRequest('Invalid hashmap format')
+
         data = ''
         for block in socket_read_iterator(request, content_length,
                                           request.backend.block_size):
             data = ''.join([data, block])
 
-        try:
-            d = json.loads(data)
-            hashmap = d['hashes']
-            size = int(d['bytes'])
-        except:
-            raise faults.BadRequest('Invalid data formatting')
+        if request.serialization == 'json':
+            try:
+                d = json.loads(data)
+                if not hasattr(d, '__getitem__'):
+                    raise faults.BadRequest('Invalid data formating')
+                hashmap = d['hashes']
+                size = int(d['bytes'])
+            except:
+                raise faults.BadRequest('Invalid data formatting')
+        elif request.serialization == 'xml':
+            try:
+                obj = etree.fromstring(data)
+                size = int(obj.attrib.get('bytes'))
+
+                hashes = obj.findall('hash')
+                hashmap = []
+                for hash in hashes:
+                    hashmap.append(hash.text)
+            except:
+                raise faults.BadRequest('Invalid data formatting')
+
         checksum = ''  # Do not set to None (will copy previous value).
     else:
         etag = request.META.get('HTTP_ETAG')

--- a/snf-pithos-app/setup.py
+++ b/snf-pithos-app/setup.py
@@ -47,7 +47,8 @@ INSTALL_REQUIRES = [
     'astakosclient',
     'snf-django-lib',
     'snf-webproject',
-    'snf-branding'
+    'snf-branding',
+    'lxml',
 ]
 
 EXTRAS_REQUIRES = {


### PR DESCRIPTION
In version 0.15 the option to create an object by providing
the object's hashmap in XML format, instead of actual data, was disabled.
This commit restores this operation by substituting
the minidom module (vulnerable to some security implications)
with the lxml module for performing the XML parsing.
It fixes also the respective test case.
