### PR TITLE
astakos: Add checks for quota limits

### DIFF
--- a/snf-astakos-app/astakos/im/functions.py
+++ b/snf-astakos-app/astakos/im/functions.py
@@ -792,6 +792,13 @@ def validate_resource_policies(policies, admin=False):
         if p_capacity > MAX_BIGINT or m_capacity > MAX_BIGINT:
             raise ProjectBadRequest(
                 "Quota limit exceeds max value %s" % MAX_BIGINT)
+        if p_capacity < 0 or m_capacity < 0:
+            raise ProjectBadRequest(
+                "Negative quota limit is not allowed")
+        if p_capacity < m_capacity:
+            raise ProjectBadRequest(
+                "Project quota limit is less than member limit for "
+                "resource '%s'" % resource_name)
         pols.append((resource_d[resource_name], m_capacity, p_capacity))
     return pols
 

--- a/snf-astakos-app/astakos/im/tests/projects.py
+++ b/snf-astakos-app/astakos/im/tests/projects.py
@@ -639,6 +639,18 @@ class ProjectAPITest(TestCase):
         status, body = self.create(ap, h_owner)
         self.assertEqual(status, 400)
 
+        ap = copy.deepcopy(ap_base)
+        ap["resources"] = {u"σέρβις1.ρίσορς11": {"member_capacity": -512,
+                                                 "project_capacity": 256}}
+        status, body = self.create(ap, h_owner)
+        self.assertEqual(status, 400)
+
+        ap = copy.deepcopy(ap_base)
+        ap["resources"] = {u"σέρβις1.ρίσορς11": {"member_capacity": 512,
+                                                 "project_capacity": 256}}
+        status, body = self.create(ap, h_owner)
+        self.assertEqual(status, 400)
+
         filters = {"state": "nonex"}
         r = client.get(reverse("api_projects"), filters, **h_owner)
         self.assertEqual(r.status_code, 400)


### PR DESCRIPTION
Check that total (project) quota limit is no less than member limit;
and that both limits are not negative.
