### PR TITLE
pithos: Recover from DB integrity errors

### DIFF
--- a/snf-pithos-backend/pithos/backends/lib/sqlalchemy/dbwrapper.py
+++ b/snf-pithos-backend/pithos/backends/lib/sqlalchemy/dbwrapper.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from sqlalchemy import create_engine
-#from sqlalchemy.event import listen
 from sqlalchemy.pool import NullPool
 from sqlalchemy.interfaces import PoolListener
 

--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -1814,10 +1814,14 @@ class ModularBackend(BaseBackend):
 
     def _put_path(self, user, parent, path,
                   update_statistics_ancestors_depth=None):
-        node = self.node.node_create(parent, path)
-        self.node.version_create(node, None, 0, '', None, user,
-                                 self._generate_uuid(), '', CLUSTER_NORMAL,
-                                 update_statistics_ancestors_depth)
+        try:
+            node = self.node.node_create(parent, path)
+        except ValueError:  # integrity error
+            node = self.node.node_lookup(path)
+        else:
+            self.node.version_create(node, None, 0, '', None, user,
+                                     self._generate_uuid(), '', CLUSTER_NORMAL,
+                                     update_statistics_ancestors_depth)
         return node
 
     def _lookup_account(self, account, create=True):


### PR DESCRIPTION
In Pithos+ atomicity is forced on the container level.
Hence, write operations in the account level can produce integrity errors.

This commit handles these cases.

In PostgreSQL, a transaction is aborted (and all the subsequent commands are ignored)
if an integrity error occurs.

Therefore, before performing an command that can produce an integrity error,
a new savepoint is defined inside the transaction,
and after the command execution, is rollbacked or committed
according to execution status.
