### PR TITLE
astakos: Use bulk_create to speed up commissions

### DIFF
--- a/snf-astakos-app/astakos/quotaholder_app/commission.py
+++ b/snf-astakos-app/astakos/quotaholder_app/commission.py
@@ -77,12 +77,10 @@ class Import(Operation):
                                   usage=usage_max)
 
         holding.usage_max = new_usage_max
-        holding.save()
 
     @classmethod
     def _finalize(cls, holding, quantity):
         holding.usage_min += quantity
-        holding.save()
 
 
 class Release(Operation):
@@ -104,12 +102,10 @@ class Release(Operation):
                                   usage=usage_min)
 
         holding.usage_min = new_usage_min
-        holding.save()
 
     @classmethod
     def _finalize(cls, holding, quantity):
         holding.usage_max -= quantity
-        holding.save()
 
 
 class Operations(object):

--- a/snf-astakos-app/astakos/quotaholder_app/tests.py
+++ b/snf-astakos-app/astakos/quotaholder_app/tests.py
@@ -83,6 +83,12 @@ class QuotaholderTest(TestCase):
         with assertRaises(NoCommissionError):
             qh.get_commission(self.client, s1+1)
 
+        r = qh.get_quota()
+        self.assertEqual(r,
+                         {(holder, source, resource1): (limit1, 0, limit1/2),
+                          (holder, source, resource2): (limit2, 0, limit2),
+                          })
+
         # commission exceptions
 
         with assertRaises(NoCapacityError) as cm:


### PR DESCRIPTION
Update holdings and create provisions and log in bulk when issuing or
resolving commissions to speed up the operation,
