### PR TITLE
ci: Name directory when git-cloning

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -791,7 +791,7 @@ class SynnefoCI(object):
         else:
             # Clone Synnefo from remote repo
             self.logger.debug("Clone synnefo from %s" % synnefo_repo)
-            self._git_clone(synnefo_repo)
+            self._git_clone(synnefo_repo, directory="synnefo")
 
         # Checkout the desired synnefo_branch
         self.logger.debug("Checkout \"%s\" branch/commit" % synnefo_branch)
@@ -828,7 +828,7 @@ class SynnefoCI(object):
         # Clone pithos-webclient from remote repo
         self.logger.debug("Clone pithos-webclient from %s" %
                           pithos_webclient_repo)
-        self._git_clone(pithos_webclient_repo)
+        self._git_clone(pithos_webclient_repo, directory="pithos-web-client")
 
         # Track all pithos-webclient branches
         cmd = """
@@ -873,7 +873,7 @@ class SynnefoCI(object):
         """.format(pithos_webclient_branch)
         _run(cmd, False)
 
-    def _git_clone(self, repo):
+    def _git_clone(self, repo, directory=""):
         """Clone repo to remote server
 
         Currently clonning from code.grnet.gr can fail unexpectedly.
@@ -883,7 +883,7 @@ class SynnefoCI(object):
         cloned = False
         for i in range(1, 11):
             try:
-                _run("git clone %s" % repo, False)
+                _run("git clone %s %s" % (repo, directory), False)
                 cloned = True
                 break
             except BaseException:


### PR DESCRIPTION
Explicitly name the directory where we clone a repo; don't rely on the
repo's name.
