### PR TITLE
debian: Add package support for snf-admin-app

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -75,6 +75,24 @@ Description: Synnefo tools to interact with Ganeti
   * snf-progress-monitor, a utility to monitor image deployment and
     produce notifications to the Synnefo queue
 
+Package: snf-admin-app
+Architecture: all
+Depends: ${misc:Depends}, ${python:Depends},
+  snf-cyclades-app (= ${binary:Version}), snf-astakos-app (= ${binary:Version}),
+  snf-common (= ${binary:Version}), snf-django-lib (= ${binary:Version}),
+  snf-branding (= ${binary:Version}), snf-webproject (= ${binary:Version}),
+  python-astakosclient (= ${binary:Version}), django-filter (>= 0.5.3),
+  python-django-eztables (= 0.3.3-1~snf~0.2)
+Provides: ${python:Provides}
+Recommends: snf-webproject
+XB-Python-Version: ${python:Versions}
+Description: Admin Dashboard package
+ Admin is the Synnefo componenent that provides to trusted users with:
+  * The ability to manage and view various different Synnefo entities such as
+    users, VMs, projects etc.
+  * Automatic generation of charts and statistics using data from the
+    Astakos/Cyclades stats.
+
 Package: snf-astakos-app
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends},

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -16,3 +16,4 @@ snf-branding snf-branding
 snf-webproject snf-webproject
 py-rrdtool python-rrdtool
 django-tables2 python-django-tables2
+django-eztables python-django-eztables

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,7 @@ PACKAGES = \
 	snf-common \
 	snf-branding \
 	snf-cyclades-app \
+	snf-admin-app \
 	snf-cyclades-gtools \
 	snf-webproject \
 	snf-pithos-app \

--- a/debian/snf-admin-app.dirs
+++ b/debian/snf-admin-app.dirs
@@ -1,0 +1,2 @@
+usr/share/synnefo/static/admin
+etc/synnefo

--- a/debian/snf-admin-app.install
+++ b/debian/snf-admin-app.install
@@ -1,0 +1,2 @@
+snf-admin-app/synnefo_admin/admin/static/* usr/share/synnefo/static/admin
+snf-admin-app/synnefo_admin/conf/* etc/synnefo

--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -39,6 +39,9 @@ docs/images/synnefo-logo.png.old
 ./snf-astakos-app/astakos/im/static/im/images/sound_lg.png
 ./snf-astakos-app/astakos/im/static/im/images/sound_g.png
 ./snf-astakos-app/astakos/im/static/im/images/accounts-logo.png
+./snf-admin-app/synnefo_admin/admin/static/img/roughcloth.png
+./snf-admin-app/synnefo_admin/admin/static/img/glyphicons-halflings-white.png
+./snf-admin-app/synnefo_admin/admin/static/img/glyphicons-halflings.png
 ./snf-cyclades-app/synnefo/helpdesk/static/img/roughcloth.png
 ./snf-cyclades-app/synnefo/helpdesk/static/img/glyphicons-halflings-white.png
 ./snf-cyclades-app/synnefo/helpdesk/static/img/glyphicons-halflings.png


### PR DESCRIPTION
This patch adds the necessary files in the `debian/` folder to create packages for Admin.
