### PR TITLE
ui: Break word for images with large names

### DIFF
--- a/snf-cyclades-app/synnefo/ui/static/snf/css/main.css
+++ b/snf-cyclades-app/synnefo/ui/static/snf/css/main.css
@@ -6218,6 +6218,7 @@ table.list-machines .wave {
     padding: 6px;
     margin-bottom:1px;
     position: relative;
+    word-wrap: break-word;
 }
 
 .create-wizard-overlay .images-list .image-details img {


### PR DESCRIPTION
Break word has been used to prevent the following output in cyclades creation wizard:
![2014-08-07-120919_1918x1049_scrot](https://cloud.githubusercontent.com/assets/2444615/3840188/264f4a04-1e1a-11e4-8d9d-14f9c1275e16.jpg)
