### PR TITLE
astakos: Lock holders when updating holdings

### DIFF
--- a/snf-astakos-app/astakos/quotaholder_app/migrations/0013_auto__add_holder.py
+++ b/snf-astakos-app/astakos/quotaholder_app/migrations/0013_auto__add_holder.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Holder'
+        db.create_table('quotaholder_app_holder', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('holder', self.gf('django.db.models.fields.CharField')(unique=True, max_length=4096, db_index=True)),
+        ))
+        db.send_create_signal('quotaholder_app', ['Holder'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Holder'
+        db.delete_table('quotaholder_app_holder')
+
+
+    models = {
+        'quotaholder_app.commission': {
+            'Meta': {'object_name': 'Commission'},
+            'clientkey': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'issue_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4096'}),
+            'serial': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'quotaholder_app.holder': {
+            'Meta': {'object_name': 'Holder'},
+            'holder': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'quotaholder_app.holding': {
+            'Meta': {'unique_together': "(('holder', 'source', 'resource'),)", 'object_name': 'Holding'},
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'limit': ('django.db.models.fields.BigIntegerField', [], {}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'usage_max': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'usage_min': ('django.db.models.fields.BigIntegerField', [], {'default': '0'})
+        },
+        'quotaholder_app.provision': {
+            'Meta': {'object_name': 'Provision'},
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'quantity': ('django.db.models.fields.BigIntegerField', [], {}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'serial': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'provisions'", 'to': "orm['quotaholder_app.Commission']"}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'})
+        },
+        'quotaholder_app.provisionlog': {
+            'Meta': {'object_name': 'ProvisionLog'},
+            'delta_quantity': ('django.db.models.fields.BigIntegerField', [], {}),
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue_time': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'limit': ('django.db.models.fields.BigIntegerField', [], {}),
+            'log_time': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'serial': ('django.db.models.fields.BigIntegerField', [], {}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'usage_max': ('django.db.models.fields.BigIntegerField', [], {}),
+            'usage_min': ('django.db.models.fields.BigIntegerField', [], {})
+        }
+    }
+
+    complete_apps = ['quotaholder_app']

--- a/snf-astakos-app/astakos/quotaholder_app/migrations/0014_holders.py
+++ b/snf-astakos-app/astakos/quotaholder_app/migrations/0014_holders.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Remember to use orm['appname.ModelName'] rather than "from appname.models..."
+        holders = set(orm.Holding.objects.all().values_list('holder', flat=True))
+        hs = [orm.Holder(holder=holder) for holder in holders]
+        orm.Holder.objects.bulk_create(hs)
+
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        'quotaholder_app.commission': {
+            'Meta': {'object_name': 'Commission'},
+            'clientkey': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'issue_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '4096'}),
+            'serial': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'quotaholder_app.holder': {
+            'Meta': {'object_name': 'Holder'},
+            'holder': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        'quotaholder_app.holding': {
+            'Meta': {'unique_together': "(('holder', 'source', 'resource'),)", 'object_name': 'Holding'},
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'limit': ('django.db.models.fields.BigIntegerField', [], {}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'usage_max': ('django.db.models.fields.BigIntegerField', [], {'default': '0'}),
+            'usage_min': ('django.db.models.fields.BigIntegerField', [], {'default': '0'})
+        },
+        'quotaholder_app.provision': {
+            'Meta': {'object_name': 'Provision'},
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'quantity': ('django.db.models.fields.BigIntegerField', [], {}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'serial': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'provisions'", 'to': "orm['quotaholder_app.Commission']"}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'})
+        },
+        'quotaholder_app.provisionlog': {
+            'Meta': {'object_name': 'ProvisionLog'},
+            'delta_quantity': ('django.db.models.fields.BigIntegerField', [], {}),
+            'holder': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'issue_time': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'limit': ('django.db.models.fields.BigIntegerField', [], {}),
+            'log_time': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'reason': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'resource': ('django.db.models.fields.CharField', [], {'max_length': '4096'}),
+            'serial': ('django.db.models.fields.BigIntegerField', [], {}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '4096', 'null': 'True'}),
+            'usage_max': ('django.db.models.fields.BigIntegerField', [], {}),
+            'usage_min': ('django.db.models.fields.BigIntegerField', [], {})
+        }
+    }
+
+    complete_apps = ['quotaholder_app']
+    symmetrical = True

--- a/snf-astakos-app/astakos/quotaholder_app/models.py
+++ b/snf-astakos-app/astakos/quotaholder_app/models.py
@@ -17,6 +17,10 @@ from django.db.models import (Model, BigIntegerField, CharField, DateTimeField,
                               ForeignKey, AutoField)
 
 
+class Holder(Model):
+    holder = CharField(max_length=4096, db_index=True, unique=True, null=False)
+
+
 class Holding(Model):
 
     holder = CharField(max_length=4096, db_index=True)


### PR DESCRIPTION
It is not safe to delete and re-insert holdings that have been locked,
because a second thread that has been blocked while retrieving the
same holdings will ultimately not get the deleted ones. Instead of
locking the holdings, we introduce a table to keep the holders and
lock these.
