### PR TITLE
astakosclient: Add simplejson as recommended package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -144,6 +144,7 @@ Package: python-astakosclient
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}
 Provides: ${python:Provides}
+Recommends: python-simplejson
 XB-Python-Version: ${python:Versions}
 Description: Synnefo Astakos Client
  Python client for Astakos, the Synnefo identity management service.


### PR DESCRIPTION
Astakosclient will fallback to Python's default 'json' package if
simplejson is not available. Still the use of 'simplejson' is
recommended since it is faster compared to the 'json' package.
