### PR TITLE
cyclades: Fix mishandling of MAX_CIDR_BLOCK setting

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -164,6 +164,8 @@ Cyclades
   are drained.
 * Fix the'network-inspect' command to not contain externally reserved IPs
   in th number of available IPs.
+* Fix mishandling of `MAX_CIDR_BLOCK` setting. Allowed CIDR sizes
+  changed from (MAX_CIDR_BLOCK, 29) to [MAX_CIDR_BLOCK, 29].
 * Fix various minor bugs.
 
 Cyclades UI

--- a/snf-cyclades-app/synnefo/logic/subnets.py
+++ b/snf-cyclades-app/synnefo/logic/subnets.py
@@ -251,17 +251,17 @@ def validate_subnet_params(subnet=None, gateway=None, subnet6=None,
 
         # Check that network size is allowed!
         prefixlen = network.prefixlen
-        if prefixlen > 29 or prefixlen <= settings.MAX_CIDR_BLOCK:
+        if prefixlen > 29 or prefixlen < settings.MAX_CIDR_BLOCK:
             raise faults.OverLimit(
                 message="Unsupported network size",
-                details="Netmask must be in range: (%s, 29]" %
+                details="Netmask must be in range: [%s, 29]" %
                 settings.MAX_CIDR_BLOCK)
         if gateway:  # Check that gateway belongs to network
             try:
                 gateway = ipaddr.IPv4Address(gateway)
             except ValueError:
                 raise faults.BadRequest("Invalid network IPv4 gateway")
-            if not gateway in network:
+            if gateway not in network:
                 raise faults.BadRequest("Invalid network IPv4 gateway")
 
     if subnet6:


### PR DESCRIPTION
Fix mishandling of MAX_CIDR_BLOCK setting. The CIDR range should be
[MAX_CIDR_BLOCK, 29] instead of (MAX_CIDR_BLOCK, 29] that was until now.
