### PR TITLE
astakos: Revert bulk update of holdings in commissions

### DIFF
--- a/snf-astakos-app/astakos/quotaholder_app/commission.py
+++ b/snf-astakos-app/astakos/quotaholder_app/commission.py
@@ -77,10 +77,12 @@ class Import(Operation):
                                   usage=usage_max)
 
         holding.usage_max = new_usage_max
+        holding.save()
 
     @classmethod
     def _finalize(cls, holding, quantity):
         holding.usage_min += quantity
+        holding.save()
 
 
 class Release(Operation):
@@ -102,10 +104,12 @@ class Release(Operation):
                                   usage=usage_min)
 
         holding.usage_min = new_usage_min
+        holding.save()
 
     @classmethod
     def _finalize(cls, holding, quantity):
         holding.usage_max -= quantity
+        holding.save()
 
 
 class Operations(object):

--- a/snf-astakos-app/astakos/quotaholder_app/tests.py
+++ b/snf-astakos-app/astakos/quotaholder_app/tests.py
@@ -138,6 +138,7 @@ class QuotaholderTest(TestCase):
         r = qh.get_pending_commissions(clientkey=self.client)
         self.assertEqual(len(r), 1)
         serial = r[0]
+        self.assertEqual(serial, s1)
         r = qh.resolve_pending_commission(self.client, serial)
         self.assertEqual(r, True)
         r = qh.get_pending_commissions(clientkey=self.client)
@@ -150,6 +151,13 @@ class QuotaholderTest(TestCase):
                   (holder, source, resource2): (limit2, limit2, limit2),
                   }
         self.assertEqual(r, quotas)
+
+        logs = models.ProvisionLog.objects.filter(serial=serial)
+        self.assertEqual(len(logs), 2)
+        log1 = filter(lambda p: p.resource == resource1
+                      and p.delta_quantity == limit1/2
+                      and p.usage_min == limit1/2, logs)
+        self.assertEqual(len(log1), 1)
 
         # resolve commissions
 


### PR DESCRIPTION
db464c6 introduced a bug: deleting holdings (and then bulk creating them)
interferes with locking; a thread that waits for holdings will not get
the deleted ones.

Revert to separate updating of holdings when issuing and resolving
commissions.
