### PR TITLE
cyclades: Add GANETI_DISKS_WAIT_FOR_SYNC setting

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -164,6 +164,8 @@ Cyclades
   are drained.
 * Fix the'network-inspect' command to not contain externally reserved IPs
   in th number of available IPs.
+* Add `GANETI_DISKS_WAIT_FOR_SYNC` setting to decide whether Ganeti will
+  wait for the disk mirror to sync (`--no-wait-for-sync` Ganeti option).
 * Fix mishandling of `MAX_CIDR_BLOCK` setting. Allowed CIDR sizes
   changed from (MAX_CIDR_BLOCK, 29) to [MAX_CIDR_BLOCK, 29].
 * Fix various minor bugs.

--- a/snf-cyclades-app/conf/20-snf-cyclades-app-backend.conf
+++ b/snf-cyclades-app/conf/20-snf-cyclades-app-backend.conf
@@ -27,7 +27,7 @@
 #    'hvparams': {'kvm': {'serial_console': False},
 #                 'xen-pvm': {},
 #                 'xen-hvm': {}},
-#    'wait_for_sync': False}
+#}
 #
 ## If True, qemu-kvm will hotplug a NIC when connecting a vm to
 ## a network. This requires qemu-kvm=1.0.
@@ -36,6 +36,10 @@
 ## If True, Ganeti will try to allocate new instances only on nodes that are
 ## not already locked. This might result in slightly unbalanced clusters.
 #GANETI_USE_OPPORTUNISTIC_LOCKING = True
+#
+## If False, Ganeti will not wait for the disk mirror to sync
+## (--no-wait-for-sync option in Ganeti). Useful only for DRBD template.
+#GANETI_DISKS_WAIT_FOR_SYNC = False
 #
 ## This module implements the strategy for allocating a vm to a backend
 #BACKEND_ALLOCATOR_MODULE = "synnefo.logic.allocators.default_allocator"

--- a/snf-cyclades-app/synnefo/app_settings/default/backend.py
+++ b/snf-cyclades-app/synnefo/app_settings/default/backend.py
@@ -27,7 +27,7 @@ GANETI_CREATEINSTANCE_KWARGS = {
     'hvparams': {"kvm": {'serial_console': False},
                  "xen-pvm": {},
                  "xen-hvm": {}},
-    'wait_for_sync': False}
+}
 
 # If True, qemu-kvm will hotplug a NIC when connecting a vm to
 # a network. This requires qemu-kvm=1.0.
@@ -36,6 +36,10 @@ GANETI_USE_HOTPLUG = True
 # If True, Ganeti will try to allocate new instances only on nodes that are
 # not already locked. This might result in slightly unbalanced clusters.
 GANETI_USE_OPPORTUNISTIC_LOCKING = True
+
+# If False, Ganeti will not wait for the disk mirror to sync
+# (--no-wait-for-sync option in Ganeti). Useful only for DRBD template.
+GANETI_DISKS_WAIT_FOR_SYNC = False
 
 # This module implements the strategy for allocating a vm to a backend
 BACKEND_ALLOCATOR_MODULE = "synnefo.logic.allocators.default_allocator"

--- a/snf-cyclades-app/synnefo/logic/backend.py
+++ b/snf-cyclades-app/synnefo/logic/backend.py
@@ -808,6 +808,9 @@ def create_instance(vm, nics, volumes, flavor, image):
 
     kw["disks"] = disks
 
+    # --no-wait-for-sync option for DRBD disks
+    kw["wait_for_sync"] = settings.GANETI_DISKS_WAIT_FOR_SYNC
+
     kw['nics'] = [{"name": nic.backend_uuid,
                    "network": nic.network.backend_id,
                    "ip": nic.ipv4_address}
@@ -1216,6 +1219,7 @@ def attach_volume(vm, volume, depends=[]):
     kwargs = {
         "instance": vm.backend_vm_id,
         "disks": [("add", "-1", disk)],
+        "wait_for_sync": settings.GANETI_DISKS_WAIT_FOR_SYNC,
         "depends": depends,
     }
     if vm.backend.use_hotplug():


### PR DESCRIPTION
Add new setting to denote whether Ganeti will wait for the disk minor to
sync (DRBD). This setting is used when creating a new instance or adding
a new disk to an existing Ganeti instance.
