### PR TITLE
docs: Update snf-image related stuff

### DIFF
--- a/docs/install-guide-debian.rst
+++ b/docs/install-guide-debian.rst
@@ -1545,11 +1545,23 @@ able to access the Pithos database. This is why, we also install them on *all*
 VM-capable Ganeti nodes.
 
 .. warning::
-		snf-image uses ``curl`` for handling URLs. This means that it will
-		not  work out of the box if you try to use URLs served by servers which do
-		not have a valid certificate. In case you haven't followed the guide's
-		directions about the certificates, in order to circumvent this you should edit the file
-		``/etc/default/snf-image``. Change ``#CURL="curl"`` to ``CURL="curl -k"`` on every node.
+    snf-image uses ``curl`` for handling URLs. This means that it will
+    not  work out of the box if you try to use URLs served by servers which do
+    not have a valid certificate. In case you haven't followed the guide's
+    directions about the certificates, in order to circumvent this you should
+    edit the file ``/etc/default/snf-image``. Change ``# CURL="curl"`` to
+    ``CURL="curl -k"`` on every node.
+
+.. warning::
+    If you are using qemu-kvm from wheezy-backports, note that the official
+    2.1.0 version has a ACPI regression bug (see
+    `here <https://lists.nongnu.org/archive/html/qemu-devel/2014-08/msg03536.html>`_).
+    This bug has reached the
+    `Debian qemu-kvm 2.1+dfsg-2~bpo70+2 package <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=759522>`_
+    found in wheezy-backports and is triggered by snf-image. Until a newer package is
+    out, you can workaround it by editing the file ``/etc/default/snf-image``
+    and changing ``# KVM="kvm"`` to ``KVM="qemu-system-x86_64 -enable-kvm -machine pc-i440fx-2.0,accel=kvm"``
+    on every node.
 
 Configuration
 ~~~~~~~~~~~~~

--- a/docs/upgrade/upgrade-0.16.rst
+++ b/docs/upgrade/upgrade-0.16.rst
@@ -8,7 +8,9 @@ Starting with version 0.16, we introduce Archipelago as the new storage backend
 for the Pithos Service. Archipelago will act as a storage abstraction layer
 between Pithos and NFS, RADOS or any other storage backend driver that Archipelago
 supports. In order to use the Pithos Service you must install Archipelago on the
-node that runs the Pithos workers.
+node that runs the Pithos workers. Additionally, you must install snf-image
+version 0.16 on the Ganeti nodes since this is the first version that supports
+Archipelago.
 
 Until now the Pithos mapfile was a simple file containing a list of hashes that
 make up the stored file in a Pithos container. After this consolidation the Pithos
@@ -139,6 +141,14 @@ The upgrade to v0.16 consists in the following steps:
 
     Installing the packages will cause services to start. Make sure you bring
     them down again (at least ``gunicorn``, ``snf-dispatcher``)
+
+.. note::
+
+    If you are using qemu-kvm from wheezy-backports, note that qemu-kvm package
+    2.1+dfsg-2~bpo70+2 has a bug that is triggered by snf-image. Check
+    `snf-image installation <https://www.synnefo.org/docs/synnefo/latest/install-guide-debian.html#installation>`_ for
+    a workaround.
+
 
 2.2 Sync and migrate the database
 ---------------------------------


### PR DESCRIPTION
- Mention the fact that snf-image 0.16 is the first version that supports
  Archipelago in the upgrade notes.
- Add instructions on how to workaround a QEMU bug found in the
  wheezy-backports package.
