### PR TITLE
pithos: Add class attribute to ModularBackend

### DIFF
--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -222,6 +222,7 @@ class ModularBackend(BaseBackend):
 
     Uses modules for SQL functions and storage.
     """
+    _class_version = 1
 
     def __init__(self, db_module=None, db_connection=None,
                  block_module=None, block_size=None, hash_algorithm=None,


### PR DESCRIPTION
Add _class_version class attribute to ModularBackend class
to differentiate between multiple backend versions.
