### PR TITLE
admin: Add setting for enabling charts

### DIFF
--- a/docs/admin-guide.rst
+++ b/docs/admin-guide.rst
@@ -1766,7 +1766,18 @@ Disabling Admin
 ---------------
 
 The easiest way to disable the Admin Dashboard is to set the `ADMIN_ENABLED`
-setting to False.
+setting to `False`.
+
+Enabling Charts
+---------------
+
+In order to enable the "Charts" view in the "Reports" tab, you must set the
+`ADMIN_ENABLE_CHARTS` setting to `True`. The charting software that is used is
+Highcharts by HighSoft AS.
+
+Due to the licensing nature of Highcharts, charts are disabled by default. You
+can view the Highcharts license [#f1]_ and the accompanying FAQ [#f2]_, to
+decide whether to enable them or not.
 
 
 List of all Synnefo components
@@ -2836,3 +2847,9 @@ Changelog, NEWS
 * v0.14.2 :ref:`Changelog <Changelog-0.14.2>`, :ref:`NEWS <NEWS-0.14.2>`
 * v0.14 :ref:`Changelog <Changelog-0.14>`, :ref:`NEWS <NEWS-0.14>`
 * v0.13 :ref:`Changelog <Changelog-0.13>`, :ref:`NEWS <NEWS-0.13>`
+
+
+.. rubric:: Footnotes
+
+.. [#f1] www.highcharts.com/license, http://shop.highsoft.com/highcharts.html
+.. [#f2] http://shop.highsoft.com/highcharts.html, http://shop.highsoft.com/faq/non-commercial

--- a/snf-admin-app/synnefo_admin/admin/static/js/charts_theme.js
+++ b/snf-admin-app/synnefo_admin/admin/static/js/charts_theme.js
@@ -1,9 +1,26 @@
-$(document).ready(function() {	
-	/**
-	 * Dark theme for Highcharts JS
-	 * @author Torstein Honsi
-	 */
+//@license Highcharts JS
 
+//License: www.highcharts.com/license, shop.highsoft.com/highcharts.html
+//Modified slightly for the use case of Synnefo.
+
+//From shop.highsoft.com/faq/non-commercial (Retrieved at September 2, 2014):
+
+    //NON-COMMERCIAL REDISTRIBUTION.
+    //------------------------------
+
+    //You are allowed to distribute a Highsoft software product with
+    //non-commercial packages given that you fulfill two conditions:
+
+    //Emphasize to your users that a Highsoft software product is not free for
+    //commercial use. You can do this on your download page or when your users
+    //activate a Highsoft software product in your application.  Provide a link
+    //back to this web page in the same location.
+
+/**
+ * Dark theme for Highcharts JS
+ * @author Torstein Honsi
+ */
+$(document).ready(function() {	
 	// Load the fonts
 	// Highcharts.createElement('link', {
 	//    href: 'http://fonts.googleapis.com/css?family=Unica+One',

--- a/snf-admin-app/synnefo_admin/admin/static/js/highstock.src.js
+++ b/snf-admin-app/synnefo_admin/admin/static/js/highstock.src.js
@@ -7,6 +7,19 @@
  * (c) 2009-2014 Torstein Honsi
  *
  * License: www.highcharts.com/license
+ *
+//From shop.highsoft.com/faq/non-commercial (Retrieved at September 2, 2014):
+
+    //NON-COMMERCIAL REDISTRIBUTION.
+    //------------------------------
+
+    //You are allowed to distribute a Highsoft software product with
+    //non-commercial packages given that you fulfill two conditions:
+
+    //Emphasize to your users that a Highsoft software product is not free for
+    //commercial use. You can do this on your download page or when your users
+    //activate a Highsoft software product in your application.  Provide a link
+    //back to this web page in the same location.
  */
 
 // JSLint options:

--- a/snf-admin-app/synnefo_admin/admin/templates/admin/base.html
+++ b/snf-admin-app/synnefo_admin/admin/templates/admin/base.html
@@ -46,7 +46,9 @@
                             <span class="snf-angle-down arrow"></span></a>
                             <ul class="dropdown-menu align-left">
                                 <li {% block nav-stats %}{%  endblock %}><a href="{% url admin-stats %}">Stats</a></li>
+                                {% if ADMIN_ENABLE_CHARTS %}
                                 <li {% block nav-charts %}{%  endblock %}><a href="{% url admin-charts %}">Charts</a></li>
+                                {% endif %}
                             </ul>
                         </li>
                     </ul>

--- a/snf-admin-app/synnefo_admin/admin/templates/admin/charts.html
+++ b/snf-admin-app/synnefo_admin/admin/templates/admin/charts.html
@@ -41,7 +41,7 @@ class="active"
 <script src="{{ MEDIA_URL }}admin/js/highstock.src.js"></script>
 <script src="{{ MEDIA_URL }}admin/js/Highcharts_drilldown.src.js"></script>
 {% if request.COOKIES.theme == 'dark' %}
-<script src="{{ MEDIA_URL }}admin/js/HighchartsDarkTheme.js"></script>
+<script src="{{ MEDIA_URL }}admin/js/charts_theme.js"></script>
 {% endif %}
 <script src="{{ MEDIA_URL }}admin/js/charts.js"></script>
 <script src="{{ MEDIA_URL }}admin/js/charts_common.js"></script>

--- a/snf-admin-app/synnefo_admin/admin/views.py
+++ b/snf-admin-app/synnefo_admin/admin/views.py
@@ -143,6 +143,7 @@ def admin_user_required(func, permitted_groups=admin_settings.\
 default_dict = {
     'ADMIN_MEDIA_URL': admin_settings.ADMIN_MEDIA_URL,
     'UI_MEDIA_URL': UI_MEDIA_URL,
+    'ADMIN_ENABLE_CHARTS': admin_settings.ADMIN_ENABLE_CHARTS,
     'mail': {
         'sender': astakos_settings.SERVER_EMAIL,
         'subject': sample_subject,
@@ -192,6 +193,10 @@ def stats(request):
 @admin_user_required
 def charts(request):
     """Charts view."""
+    if not admin_settings.ADMIN_ENABLE_CHARTS:
+        raise AdminHttp404("The charting functionality has been disabled.\n"
+                           "For more information, please consult the Synnefo "
+                           "settings.")
     admin_log(request)
     return direct_to_template(request, "admin/charts.html",
                               extra_context=default_dict)

--- a/snf-admin-app/synnefo_admin/admin_settings.py
+++ b/snf-admin-app/synnefo_admin/admin_settings.py
@@ -33,6 +33,18 @@ AUTH_COOKIE_NAME = getattr(settings, 'ADMIN_AUTH_COOKIE_NAME',
                            getattr(settings, 'UI_AUTH_COOKIE_NAME',
                                    '_pithos2_a'))
 
+# This setting enables the charts presentation of Astakos/Cyclades resources.
+# The charting software that is used is Highcharts by HighSoft AS.
+#
+# Due to the licensing nature of Highcharts, it is disabled by default. You can
+# view the Highcharts license [1] and the accompanying FAQ [2], to decide
+# whether to enable it or not.
+#
+# [1]: www.highcharts.com/license, http://shop.highsoft.com/highcharts.html
+# [2]: http://shop.highsoft.com/highcharts.html,
+#      http://shop.highsoft.com/faq/non-commercial
+ADMIN_ENABLE_CHARTS = getattr(settings, 'ADMIN_ENABLE_CHARTS', False)
+
 # A dictionary with the enabled admin model views.
 DEFAULT_ADMIN_VIEWS = {
     'user': {'label': 'Users'},

--- a/snf-admin-app/synnefo_admin/conf/20-snf-admin-app-general.conf
+++ b/snf-admin-app/synnefo_admin/conf/20-snf-admin-app-general.conf
@@ -6,6 +6,18 @@
 #ADMIN_MEDIA_URL = ""
 #ADMIN_AUTH_COOKIE_NAME = '_pithos2_a'
 
+# This setting enables the charts presentation of Astakos/Cyclades resources.
+# The charting software that is used is Highcharts by HighSoft AS.
+#
+# Due to the licensing nature of Highcharts, it is disabled by default. You can
+# view the Highcharts license [1] and the accompanying FAQ [2], to decide
+# whether to enable it or not.
+#
+# [1]: www.highcharts.com/license, http://shop.highsoft.com/highcharts.html
+# [2]: http://shop.highsoft.com/highcharts.html,
+#      http://shop.highsoft.com/faq/non-commercial
+#ADMIN_ENABLE_CHARTS = False
+
 ## A dictionary with the enabled admin model views.
 #ADMIN_VIEWS = {
 #    'user': {'label': 'Users'},


### PR DESCRIPTION
Add a setting (ADMIN_ENABLE_CHARTS) for enabling the charts presentation
of Astakos/Cyclades resources. This setting will default to False.

The charting software that is used is Highcharts by HighSoft AS. It is
due to the licensing nature of Highcharts that charts are disabled by
default. You can view the Highcharts license (1) and the accompanying
FAQ (2), to decide whether to enable it or not.

(1): www.highcharts.com/license, http://shop.highsoft.com/highcharts.html
(2): http://shop.highsoft.com/highcharts.html,
     http://shop.highsoft.com/faq/non-commercial
