### PR TITLE
astakos: Wrong module names in MESSAGES_VIEWS_MAP

### DIFF
--- a/snf-astakos-app/astakos/im/templatetags/astakos_tags.py
+++ b/snf-astakos-app/astakos/im/templatetags/astakos_tags.py
@@ -30,14 +30,14 @@ from django.utils.safestring import mark_safe
 register = template.Library()
 
 MESSAGES_VIEWS_MAP = getattr(settings, 'ASTAKOS_MESSAGES_VIEWS_MAP', {
-    'astakos.im.views.index': 'LOGIN_MESSAGES',
-    'astakos.im.views.logout': 'LOGIN_MESSAGES',
-    'astakos.im.views.login': 'LOGIN_MESSAGES',
-    'astakos.im.views.signup': 'SIGNUP_MESSAGES',
-    'astakos.im.views.edit_profile': 'PROFILE_MESSAGES',
-    'astakos.im.views.change_password': 'PROFILE_MESSAGES',
-    'astakos.im.views.invite': 'PROFILE_MESSAGES',
-    'astakos.im.views.feedback': 'PROFILE_MESSAGES',
+    'astakos.im.views.im.index': 'LOGIN_MESSAGES',
+    'astakos.im.views.im.logout': 'LOGIN_MESSAGES',
+    'astakos.im.views.im.login': 'LOGIN_MESSAGES',
+    'astakos.im.views.im.signup': 'SIGNUP_MESSAGES',
+    'astakos.im.views.im.edit_profile': 'PROFILE_MESSAGES',
+    'astakos.im.views.im.change_password': 'PROFILE_MESSAGES',
+    'astakos.im.views.im.invite': 'PROFILE_MESSAGES',
+    'astakos.im.views.im.feedback': 'PROFILE_MESSAGES',
 })
 
 


### PR DESCRIPTION
During the patch 'astakos: reorganize views' the module 'im/views.py'
was transformed into a directory and the code was moved to
'im/views/im.py'. Fix the wrong module names in MESSAGES_VIEWS_MAP
dictionary so that ASTAKOS_*_MESSAGES will be displayed.
