### PR TITLE
branding: BRANDING_FONTS_CSS_URLS not defined

### DIFF
--- a/snf-branding/conf/15-snf-branding-settings.conf
+++ b/snf-branding/conf/15-snf-branding-settings.conf
@@ -57,7 +57,7 @@
 # the default application styles. Use `//` prefix as defined 
 # in default urls if you serve Synnefo application over both http and https 
 # protocols (NOT RECOMMENDED).
-#FONTS_CSS_URLS = getattr(settings, 'BRANDING_FONTS_CSS_URLS', [
+#BRANDING_FONTS_CSS_URLS = [
 #    '//fonts.googleapis.com/css?family=Open+Sans&subset=latin,greek-ext,greek',
 #    '//fonts.googleapis.com/css?family=Ubuntu&subset=latin,greek'
-#])
+#]


### PR DESCRIPTION
Define the 'BRANDING_FONTS_CSS_URLS' parameter in the config file.
