### PR TITLE
Fix burnin bug: Index error in pithos account_get

### DIFF
--- a/snf-tools/synnefo_tools/burnin/pithos_tests.py
+++ b/snf-tools/synnefo_tools/burnin/pithos_tests.py
@@ -111,14 +111,13 @@ class PithosTestSuite(BurninTests):
         self.info('Limit works')
 
         resp = pithos.account_get(marker='cont')
-        cont1, cont3 = resp.json[0], resp.json[2]
+        cont1 = resp.json[0]
         self.info('Marker works')
 
         resp = pithos.account_get(limit=2, marker='cont')
         conames = [container['name'] for container in resp.json if (
             container['name'].lower().startswith('cont'))]
         self.assertTrue(cont1['name'] in conames)
-        self.assertFalse(cont3['name'] in conames)
         self.info('Marker-limit combination works')
 
         resp = pithos.account_get(show_only_shared=True)
@@ -1100,7 +1099,7 @@ class PithosTestSuite(BurninTests):
         for o in pithos.list_objects():
             if o['bytes']:
                 f_name, f_size = o['name'], o['bytes']
-                break;
+                break
         resp = pithos.object_move(
             f_name,
             destination='/%s/%s' % (self.temp_containers[-2], obj))


### PR DESCRIPTION
Bug description: pithos test assumed there are always some extra
containers in the tested pithos account and checked for their
existence, causing an Index error to be raised when starting the
test with an empty account.

Solution: Do not check for containers outside the ones created
specifically for the test.
