### PR TITLE
astakosclient: Create exception 'ConnectionError'

### DIFF
--- a/astakosclient/astakosclient/__init__.py
+++ b/astakosclient/astakosclient/__init__.py
@@ -33,7 +33,8 @@ from astakosclient.utils import \
     retry_dec, scheme_to_class, parse_request, check_input, join_urls
 from astakosclient.errors import \
     AstakosClientException, Unauthorized, BadRequest, NotFound, Forbidden, \
-    NoUserName, NoUUID, BadValue, QuotaLimit, InvalidResponse, NoEndpoints
+    NoUserName, NoUUID, BadValue, QuotaLimit, InvalidResponse, NoEndpoints, \
+    ConnectionError
 
 
 # --------------------------------------------------------------------
@@ -287,7 +288,7 @@ class AstakosClient(object):
                     status=status, message=message, data=data)
         except Exception as err:
             self.logger.error("Failed to send request: %s" % repr(err))
-            raise AstakosClientException(str(err))
+            raise ConnectionError(err)
 
         # Return
         self.logger.debug("Request returned with status %s" % status)

--- a/astakosclient/astakosclient/errors.py
+++ b/astakosclient/astakosclient/errors.py
@@ -20,13 +20,21 @@ Astakos Client Exceptions
 
 class AstakosClientException(Exception):
     """Base AstakosClientException Class"""
-    def __init__(self, message='', details='', status=500):
+    def __init__(self, message='', details='', status=500, errobject=None):
         self.message = message
         self.details = details
+        self.errobject = errobject
         if not hasattr(self, 'status'):
             self.status = status
         super(AstakosClientException,
               self).__init__(self.message, self.details, self.status)
+
+
+class ConnectionError(AstakosClientException):
+    """Connection failed"""
+    def __init__(self, errobject):
+        super(ConnectionError, self).__init__(
+            message=str(errobject), errobject=errobject)
 
 
 class BadValue(AstakosClientException):


### PR DESCRIPTION
When astakosclient fails to connect to the remote server, raise a
'ConnectionError'. This exception contains the original Exception
thrown by httplib so that it can be used by other clients such as kamaki.
