### PR TITLE
pithos: Fix bug when copying mapfiles

### DIFF
--- a/snf-pithos-backend/pithos/backends/lib/hashfiler/archipelagomapper.py
+++ b/snf-pithos-backend/pithos/backends/lib/hashfiler/archipelagomapper.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from binascii import hexlify
 import ctypes
 import ConfigParser
 import logging
@@ -92,12 +91,11 @@ class ArchipelagoMapper(object):
         self.ioctx_pool.pool_put(ioctx)
         return hashes
 
-
     def map_stor(self, maphash, hashes, size, block_size):
         """Store hashes in the given hashes map."""
         objects = list()
         for h in hashes:
-            objects.append({'name': hexlify(h), 'flags': XF_MAPFLAG_READONLY})
+            objects.append({'name': h, 'flags': XF_MAPFLAG_READONLY})
         ioctx = self.ioctx_pool.pool_get()
         req = Request.get_create_request(ioctx, self.mapperd_port,
                                          maphash,

--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -1430,7 +1430,7 @@ class ModularBackend(BaseBackend):
             user, account, container, name, size, type, hexlified, checksum,
             domain, meta, replace_meta, permissions, is_snapshot=False)
         if size != 0:
-            self.store.map_put(mapfile, map_, size, self.block_size)
+            self.store.map_put(mapfile, hashmap, size, self.block_size)
         return dest_version_id, hexlified
 
     @debug_method
@@ -1530,7 +1530,6 @@ class ModularBackend(BaseBackend):
                 raise NotAllowedError("Copy is not permitted: failed to get "
                                       "source object's mapfile: %s" %
                                       src_mapfile)
-            hashmap = map(self._unhexlify_hash, hashmap)
             self.store.map_put(dest_mapfile, hashmap, size, self.block_size)
 
         dest_versions.append(dest_version_id)
@@ -1594,7 +1593,6 @@ class ModularBackend(BaseBackend):
                         raise NotAllowedError(
                             "Copy is not permitted: failed to get "
                             "source object's mapfile: %s" % src_mapfile)
-                    hashmap = map(self._unhexlify_hash, hashmap)
                     self.store.map_put(dest_mapfile, hashmap, size,
                                        self.block_size)
 


### PR DESCRIPTION
All Archipelago resources contain hexlified objects so after
copying or moving a Pithos object representing a snapshot
the new mapfile should contain the same hexlified objects.
