### PR TITLE
docs: Add a warning for RC versions of CentOS

### DIFF
--- a/docs/install-guide-centos.rst
+++ b/docs/install-guide-centos.rst
@@ -3,6 +3,13 @@
 Administrator's Installation Guide (on CentOS 6.5)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. warning::
+
+    Currently, we don't provide packages for release candidate versions of
+    Synnefo for CentOS 6.5. Please consult the docs for `Synnefo 0.15.2
+    <https://www.synnefo.org/docs/synnefo/0.15.2/index.html>`_
+    instead.
+
 This is the Administrator's installation guide on CentOS 6.5.
 
 It describes how to install the whole Synnefo stack on two (2) physical nodes,


### PR DESCRIPTION
Currently, we don't provide packages for release candidate versions
of Synnefo for CentOS 6.5. This commit adds a warning in the CentOS
installation guide to reflect this and direct users to an archived
version of the Synnefo 0.15.2 docs.
