### PR TITLE
snf_django: Fix escaping of control characters

### DIFF
--- a/snf-django-lib/snf_django/management/commands/__init__.py
+++ b/snf-django-lib/snf_django/management/commands/__init__.py
@@ -215,7 +215,10 @@ class SynnefoCommand(BaseCommand):
         return parser
 
     def pprint_table(self, *args, **kwargs):
-        utils.pprint_table(self.stdout, *args, **kwargs)
+        return utils.pprint_table(self.stdout, *args, **kwargs)
+
+    def escape_ctrl_chars(self, *args, **kwargs):
+        return utils.escape_ctrl_chars(*args, **kwargs)
 
 
 class ListCommand(SynnefoCommand):


### PR DESCRIPTION
Fix escaping of control characters from string and unicode objects. The
function 'safe_string' has been renamed to 'escape_ctrl_chars'.
Also, this function has been applied to the output of 'pprint_table'
utility function and has been added as a method of the 'SynnefoCommand'
class.
