### PR TITLE
deploy: Remove '~okeanos' references from settings

### DIFF
--- a/snf-deploy/files/etc/synnefo/astakos.conf
+++ b/snf-deploy/files/etc/synnefo/astakos.conf
@@ -2,7 +2,7 @@ CLOUDBAR_LOCATION = 'https://%ACCOUNTS%/static/im/cloudbar/'
 CLOUDBAR_SERVICES_URL = 'https://%ACCOUNTS%/astakos/ui/get_services'
 CLOUDBAR_MENU_URL = 'https://%ACCOUNTS%/astakos/ui/get_menu'
 
-ASTAKOS_DEFAULT_FROM_EMAIL = 'okeanos feedback@%DOMAIN%>'
+ASTAKOS_DEFAULT_FROM_EMAIL = 'synnefo_feedback@%DOMAIN%>'
 ASTAKOS_DEFAULT_CONTACT_EMAIL = 'feedback@%DOMAIN%'
 ASTAKOS_DEFAULT_ADMIN_EMAIL = 'feedback@%DOMAIN%'
 
@@ -10,7 +10,7 @@ ASTAKOS_IM_MODULES = ['local']
 
 ASTAKOS_BASE_URL = 'https://%ACCOUNTS%/astakos'
 
-ASTAKOS_SITENAME = '~okeanos'
+ASTAKOS_SITENAME = 'Synnefo'
 ASTAKOS_RECAPTCHA_PUBLIC_KEY = '6LeFidMSAAAAAM7Px7a96YQzsBcKYeXCI_sFz0Gk'
 ASTAKOS_RECAPTCHA_PRIVATE_KEY = '6LeFidMSAAAAAFv5U5NSayJJJhr0roludAidPd2M'
 


### PR DESCRIPTION
Change:
- 'ASTAKOS_SITENAME' setting value from '~okeanos' to 'Synnefo'
- 'ASTAKOS_DEFAULT_FROM_EMAIL' setting to 'synnefo_feedback'
