### PR TITLE
docs: Update BlockStorage API guide

### DIFF
--- a/docs/blockstorage-api-guide.rst
+++ b/docs/blockstorage-api-guide.rst
@@ -668,7 +668,7 @@ List all snapshots related to the user.
 URI                    Method Cyclades OS/Block Storage
 ====================== ====== ======== ==========
 ``/snapshots``         GET    ✔        ✔
-``/snapshotss/detail`` GET    ✔        ✔
+``/snapshots/detail``  GET    ✔        ✔
 ====================== ====== ======== ==========
 
 * Both requests return a list of snapshots. The first returns just ``id``,
@@ -727,18 +727,32 @@ The snapshot attributes are listed `here <#snapshot-ref>`_
         ],
         "id": "42",
         "display_name": "Snapshot One",
+        "status": "ACTIVE",
+        "size": 2,
+        "display_description": null,
+        "created_at": "2014-05-19T19:52:04.949734",
+        "metadata": {},
+        "volume_id": "123",
+        "os-extended-snapshot-attribute:progress": "100%"
       }, {
         "links": [
           {
-            "href": "https://example.org/cyclades/v2/snapshots/42",
+            "href": "https://example.org/cyclades/v2/snapshots/43",
             "rel": "self"
           }, {
-            "href": "https://example.org/cyclades/v2/snapshots/42",
+            "href": "https://example.org/cyclades/v2/snapshots/43",
             "rel": "bookmark"
           }
         ],
-        "id": "42",
+        "id": "43",
         "display_name": "Snapshot Two",
+        "status": "ACTIVE",
+        "size": 3,
+        "display_description": null,
+        "created_at": "2014-05-20T19:52:04.949734",
+        "metadata": {},
+        "volume_id": "124",
+        "os-extended-snapshot-attribute:progress": "100%"
       }
     ]
   }


### PR DESCRIPTION
According to the Cinder API documentation the GET /snapshots and GET
/snapshots/detail call should return the same detailed results. Cyclades
behave correctly on this matter, but the BlockStorage API guide contains
incorrect and misleading examples.

This commit fixes the above issue.
