### PR TITLE
deploy: Add 'ssl-cert-snakeoil' to the CA bundle

### DIFF
--- a/snf-deploy/snfdeploy/components.py
+++ b/snf-deploy/snfdeploy/components.py
@@ -1613,6 +1613,23 @@ class Kamaki(base.Component):
         self.ADMIN.make_user_admin_user()
 
     @base.run_cmds
+    def prepare(self):
+        cmd = """
+cat >> /etc/ca-certificates.conf <<EOF
+
+# Deploy local certificate
+local.org/snakeoil.crt
+EOF
+"""
+        return [
+            "mkdir -p /usr/share/ca-certificates/local.org",
+            "cp /etc/ssl/certs/ssl-cert-snakeoil.pem \
+                /usr/share/ca-certificates/local.org/snakeoil.crt",
+            cmd,
+            "update-ca-certificates",
+            ]
+
+    @base.run_cmds
     def initialize(self):
         url = "https://%s/astakos/identity/v2.0" % self.ctx.astakos.cname
         token = context.user_auth_token


### PR DESCRIPTION
Deploy uses the ssl-cert-snakeoil certificate when configures apache.
Add the above self signed certificate to the system's CA bundle so that
kamaki can use it to verify the connections.
