### PR TITLE
cyclades: Add --public option to image and snapshot list commands

### DIFF
--- a/snf-cyclades-app/synnefo/plankton/management/commands/image-list.py
+++ b/snf-cyclades-app/synnefo/plankton/management/commands/image-list.py
@@ -21,15 +21,19 @@ from synnefo.plankton.backend import PlanktonBackend
 
 
 class Command(SynnefoCommand):
-    help = "List public images or images available to a user."
+    help = "List images."
     option_list = SynnefoCommand.option_list + (
         make_option(
             '--user',
             dest='userid',
             default=None,
-            help="List all images available to that user."
-                 " If no user is specified, only public images"
-                 " are displayed."),
+            help="List only images that are available to this user."),
+        make_option(
+            '--public',
+            dest='public',
+            action="store_true",
+            default=False,
+            help="List only public images."),
     )
 
     def handle(self, **options):
@@ -38,6 +42,8 @@ class Command(SynnefoCommand):
 
         with PlanktonBackend(user) as backend:
             images = backend.list_images(user, check_permissions=check_perm)
+            if options["public"]:
+                images = filter(lambda x: x['is_public'], images)
             images.sort(key=lambda x: x['created_at'], reverse=True)
 
         headers = ("id", "name", "user.uuid", "public", "snapshot")

--- a/snf-cyclades-app/synnefo/volume/management/commands/snapshot-list.py
+++ b/snf-cyclades-app/synnefo/volume/management/commands/snapshot-list.py
@@ -22,15 +22,19 @@ from synnefo.plankton.backend import PlanktonBackend
 
 
 class Command(SynnefoCommand):
-    help = "List public snapshots or snapshots available to a user."
+    help = "List snapshots."
     option_list = SynnefoCommand.option_list + (
         make_option(
             '--user',
             dest='userid',
             default=None,
-            help="List all snapshots available to that user."
-                 " If no user is specified, only public snapshots"
-                 " are displayed."),
+            help="List only snapshots that are available to this user."),
+        make_option(
+            '--public',
+            dest='public',
+            action="store_true",
+            default=False,
+            help="List only public snapshots."),
     )
 
     def handle(self, **options):
@@ -40,6 +44,8 @@ class Command(SynnefoCommand):
         with PlanktonBackend(user) as backend:
             snapshots = backend.list_snapshots(user,
                                                check_permissions=check_perm)
+            if options['public']:
+                snapshots = filter(lambda x: x['is_public'], snapshots)
 
         headers = ("id", "name", "volume_id", "size", "mapfile", "status",
                    "owner", "is_public")


### PR DESCRIPTION
Add '--public' option to 'image-list' and 'snapshot-list' management
commands. Also, fix stale help message of '--user' option.
