### PR TITLE
admin: Return QuerySet when a filter has no input

### DIFF
--- a/snf-admin-app/synnefo_admin/admin/resources/projects/filters.py
+++ b/snf-admin-app/synnefo_admin/admin/resources/projects/filters.py
@@ -88,6 +88,8 @@ application_status_choices = get_application_status_choices()
 def filter_project_status(queryset, choices):
     """Filter project status."""
     choices = choices or ()
+    if not choices:
+        return queryset
     if len(choices) == len(project_status_choices):
         return queryset
     q = Q()
@@ -100,6 +102,8 @@ def filter_project_status(queryset, choices):
 def filter_application_status(queryset, choices):
     """Filter application status."""
     choices = choices or ()
+    if not choices:
+        return queryset
     if len(choices) == len(application_status_choices):
         return queryset
     q = Q()

--- a/snf-admin-app/synnefo_admin/admin/resources/volumes/filters.py
+++ b/snf-admin-app/synnefo_admin/admin/resources/volumes/filters.py
@@ -73,6 +73,8 @@ def filter_project(queryset, queries):
 
 
 def filter_disk_template(queryset, choices):
+    if not query:
+        return queryset
     choices = choices or ()
     dt_choices = get_disk_template_choices()
     if len(choices) == len(dt_choices):
@@ -84,7 +86,9 @@ def filter_disk_template(queryset, choices):
 
 
 def filter_index(queryset, query):
-    if not query.isdigit():
+    if not query:
+        return queryset
+    elif not query.isdigit():
         return queryset.none()
     return queryset.filter(index=query)
 


### PR DESCRIPTION
If a filter has not been given an input, then `django-filter` should
normally not call its function. However, it seems this is not the case
with the index Volume filter, whose function is called with no value and
as a result, it returns an empty `QuerySet`.

Fix this issue by checking in `filter_index` if it has been passed with
any parameters. Also, since this issue may appear in other filter
functions too, add the same check in every function that doesn't have
it.

NOTE: Model filters have a decorator that automatically does this check
for them.
