### PR TITLE
cyclades: Use X-UA-Compatible meta tag

### DIFF
--- a/snf-cyclades-app/synnefo/ui/templates/home.html
+++ b/snf-cyclades-app/synnefo/ui/templates/home.html
@@ -5,7 +5,7 @@
 <head>
     <title>{{ BRANDING_SERVICE_NAME }}</title>
     
-    <!--<meta http-equiv="X-UA-Compatible" content="IE=7">-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     
 


### PR DESCRIPTION
Using this tag we explicitly set the Compatibility mode for Internet
Explorer to 'Standard'.
