### PR TITLE
gtools: Fix a race in the cpustats collectd plugin

### DIFF
--- a/snf-cyclades-gtools/collectd/plugins/ganeti-cpustats.py
+++ b/snf-cyclades-gtools/collectd/plugins/ganeti-cpustats.py
@@ -28,6 +28,9 @@ def cpustats(data=None):
         vcpus = get_vcpus(pid)
         proc.close()
 
+        if vcpus == 0:
+            continue
+
         vl = collectd.Values(type="derive")
         vl.host = instance
         vl.plugin = "cpu"


### PR DESCRIPTION
If the VM has just been started, the cpustats collectd plugin might try
to read /proc/<pid>/fd/ for VCPUs fds, before qemu has initialized /
created the VCPUs. This led to a ZeroDivision error in the collectd
plugin. Make sure to skip that particular VM until the VCPUs have been
created.
