### PR TITLE
Use proper delimiter for excluded packages

### DIFF
--- a/ci/tests.sh
+++ b/ci/tests.sh
@@ -4,7 +4,7 @@ set -e
 runAstakosTests () {
     if [ -z "$astakos_tests" ]; then return; fi
 
-    export SYNNEFO_EXCLUDE_PACKAGES="snf-cyclades-app snf-admin-app snf-pithos-app"
+    export SYNNEFO_EXCLUDE_PACKAGES="snf-cyclades-app:snf-admin-app:snf-pithos-app"
     CURRENT_COMPONENT=astakos
     createSnfManageTest $astakos_tests
     runTest
@@ -13,7 +13,7 @@ runAstakosTests () {
 runCycladesTests () {
     if [ -z "$cyclades_tests" ]; then return; fi
 
-    export SYNNEFO_EXCLUDE_PACKAGES="snf-pithos-app snf-astakos-app snf-admin-app"
+    export SYNNEFO_EXCLUDE_PACKAGES="snf-pithos-app:snf-astakos-app:snf-admin-app"
     CURRENT_COMPONENT=synnefo
     createSnfManageTest $cyclades_tests
     runTest
@@ -31,7 +31,7 @@ runAdminTests () {
 runPithosTests () {
     if [ -z "$pithos_tests" ]; then return; fi
 
-    export SYNNEFO_EXCLUDE_PACKAGES="snf-cyclades-app snf-astakos-app"
+    export SYNNEFO_EXCLUDE_PACKAGES="snf-cyclades-app:snf-astakos-app:snf-admin-app"
     CURRENT_COMPONENT=pithos
     createSnfManageTest $pithos_tests
     runTest


### PR DESCRIPTION
The proper delimiter for `SYNNEFO_EXCLUDE_PACKAGES` should be ":", not " ". Also, exclude the snf-admin-app when testing Pithos.

This typo may seem trivial, but it's actually pretty severe. The Cyclades package is not excluded when running Pithos tests, meaning that since commit b4d4b74c78a595b3 (July 22), the automated daily tests for Pithos were not running and instead, the Cyclades api tests were running two times. This bug was lurking since commit 4bf0477b401d (April 17), but luckily the Cyclades package was excluded properly then.

Credits for finding this bug go to @papagian. Apologies for the major screw-up...
