### PR TITLE
cyclades: Fix minor bug when taking snapshots

### DIFF
--- a/snf-cyclades-app/synnefo/volume/snapshots.py
+++ b/snf-cyclades-app/synnefo/volume/snapshots.py
@@ -114,6 +114,7 @@ def create(user_id, volume, name, description, metadata, force=False):
         except:
             # If failed to enqueue job to Ganeti, mark snapshot as ERROR
             b.update_snapshot_state(snapshot_id, OBJECT_ERROR)
+            raise
 
         # Store the backend and job id as metadata in the snapshot in order
         # to make reconciliation based on the Ganeti job possible.


### PR DESCRIPTION
When we cannot send a Ganeti job for a snapshot, we must re-raise the
exception after setting the snapshot's status to error.
