### PR TITLE
burnin: Get 'ignore_ssl' option from kamaki config

### DIFF
--- a/ci/snf-ci
+++ b/ci/snf-ci
@@ -139,7 +139,7 @@ def main():  # pylint: disable=too-many-statements, too-many-branches
                       default=True, action="store_false",
                       help="Don't use colorful output messages.")
     parser.add_option("--ignore-ssl", "-k", dest="ignore_ssl",
-                      default=False, action="store_true",
+                      default=None, action="store_true",
                       help="Don't verify SSL certificates.")
 
     (options, args) = parser.parse_args()

--- a/snf-tools/synnefo_tools/burnin/__init__.py
+++ b/snf-tools/synnefo_tools/burnin/__init__.py
@@ -91,7 +91,7 @@ def parse_arguments(args):
         help="The token to use for authentication to the API")
     parser.add_option(
         "--ignore-ssl", "-k", action="store_true",
-        default=False, dest="ignore_ssl",
+        default=None, dest="ignore_ssl",
         help="Don't verify SSL certificates")
     parser.add_option(
         "--failfast", action="store_true",


### PR DESCRIPTION
If '-k' flag is not given, try to retrieve it from kamaki's config file.
