### PR TITLE
collectd: Read only the first line of the pid file

### DIFF
--- a/snf-cyclades-gtools/collectd/plugins/ganeti-cpustats.py
+++ b/snf-cyclades-gtools/collectd/plugins/ganeti-cpustats.py
@@ -20,7 +20,7 @@ def cpustats(data=None):
     for file in glob("/var/run/ganeti/kvm-hypervisor/pid/*"):
         instance = os.path.basename(file)
         try:
-            pid = int(open(file, "r").read())
+            pid = int(open(file, "r").readline())
             proc = open("/proc/%d/stat" % pid, "r")
             cputime = [int(proc.readline().split()[42])]
         except EnvironmentError:


### PR DESCRIPTION
Since qemu doesn't truncate the pid file when it opens / creates it,
there's a chance that the pid file will contain more than one lines,
with truncated older PIDs. Read only the first line of the pid file, to
avoid an exception in the cpustats collectd plugin.
