### PR TITLE
cyclades: Fix wait-for-sync on stopped instances

### DIFF
--- a/snf-cyclades-app/synnefo/logic/backend.py
+++ b/snf-cyclades-app/synnefo/logic/backend.py
@@ -1246,9 +1246,15 @@ def attach_volume(vm, volume, depends=[]):
     kwargs = {
         "instance": vm.backend_vm_id,
         "disks": [("add", "-1", disk)],
-        "wait_for_sync": settings.GANETI_DISKS_WAIT_FOR_SYNC,
         "depends": depends,
     }
+
+    if vm.operstate == "STARTED":
+        # Pass '--no-wait-for-sync' Ganeti option only if the instance is
+        # started because Ganeti will complain that this option cannot be
+        # used for deactivated disks.
+        kwargs["wait_for_sync"] = settings.GANETI_DISKS_WAIT_FOR_SYNC
+
     if vm.backend.use_hotplug():
         kwargs["hotplug_if_possible"] = True
     if settings.TEST:


### PR DESCRIPTION
Pass 'wait_for_sync' option only on started Ganeti instances, because Ganeti
will fail with 'OpPrereqError' in case the 'wait_for_sync' is set to
False and the instance has deactivated disks.

Note that Cyclades will not let a user neither attach a volume to an instance
that is is in transition state, e.g. stopping, nor change the state of
an instance if there is a pending volume attachment. However, in case
the administrator manually modifies the instance via Ganeti, there is a
race between checking the state of the instance and the time that Ganeti
job will run that cannot be prevented.

Closes grnet/synnefo#314
