### PR TITLE
docs: Update docs to comply with Ganeti 2.10

### DIFF
--- a/docs/install-guide-centos.rst
+++ b/docs/install-guide-centos.rst
@@ -1871,7 +1871,7 @@ Then, provide connectivity mode and link to the network:
 
 .. code-block:: console
 
-   # gnt-network connect test-net-public bridged br1
+   # gnt-network connect --nic-parameters mode=bridged,link=br1 test-net-public
 
 Now, it is time to test that the backend infrastracture is correctly setup for
 the Public Network. We will add a new VM, almost the same way we did it on the
@@ -1932,7 +1932,7 @@ means that the instances will have a second NIC connected to the ``br2``.
 .. code-block:: console
 
    # gnt-network add --network=192.168.1.0/24 --mac-prefix=aa:00:55 --tags=nfdhcpd,private-filtered test-net-prv-mac
-   # gnt-network connect test-net-prv-mac bridged br2
+   # gnt-network connect --nic-parameters mode=bridged,link=br2 test-net-prv-mac
 
    # gnt-instance add -o snf-image+default --os-parameters \
                       img_passwd=my_vm_example_passw0rd,img_format=diskdump,img_id=debian_base-6.0-x86_64,img_properties='{"OSFAMILY":"linux"\,"ROOT_PARTITION":"1"}' \

--- a/docs/install-guide-debian.rst
+++ b/docs/install-guide-debian.rst
@@ -1949,7 +1949,7 @@ Then, provide connectivity mode and link to the network:
 
 .. code-block:: console
 
-   # gnt-network connect test-net-public bridged br1
+   # gnt-network connect --nic-parameters mode=bridged,link=br1 test-net-public
 
 Now, it is time to test that the backend infrastracture is correctly setup for
 the Public Network. We will add a new VM, almost the same way we did it on the
@@ -2010,7 +2010,7 @@ means that the instances will have a second NIC connected to the ``br2``.
 .. code-block:: console
 
    # gnt-network add --network=192.168.1.0/24 --mac-prefix=aa:00:55 --tags=nfdhcpd,private-filtered test-net-prv-mac
-   # gnt-network connect test-net-prv-mac bridged br2
+   # gnt-network connect --nic-parameters mode=bridged,link=br2 test-net-prv-mac
 
    # gnt-instance add -o snf-image+default --os-parameters \
                       img_passwd=my_vm_example_passw0rd,img_format=diskdump,img_id=debian_base-6.0-x86_64,img_properties='{"OSFAMILY":"linux"\,"ROOT_PARTITION":"1"}' \

--- a/docs/networks.rst
+++ b/docs/networks.rst
@@ -122,14 +122,14 @@ Existing network flavors are the following:
 Flavor Name      Mode      Link                              MAC prefix              Tags
 ==============   =======   ===============================   ======================  ==================
 IP_LESS_ROUTED   routed    ``snf-link-$network_id``          ``DEFAULT_MAC_PREFIX``  'ip-less-routed'
-MAC_FILTERED     bridged   ``DEFAULT_MAC_FILTERED_BRIDGE``   'pool'                  'private'filtered'
-PHYSICAL_VLAN    bridged   'pool'                            ``DEFAULT_MAC_PREFIX``  'physical-vlan'
+MAC_FILTERED     bridged   ``DEFAULT_MAC_FILTERED_BRIDGE``   ``pool``                'private'filtered'
+PHYSICAL_VLAN    bridged   ``pool``                          ``DEFAULT_MAC_PREFIX``  'physical-vlan'
 CUSTOM           bridged   ``DEFAULT_BRIDGE``                ``DEFAULT_MAC_PREFIX``
 ==============   =======   ===============================   ======================  ==================
 
 ``DEFAULT_MAC_PREFIX``, ``DEFAULT_BRIDGE``,
 ``DEFAULT_MAC_FILTERED_BRIDGE`` are all configurable settings in
-``/etc/synnefo/20-snf-cyclades-app-api.conf``. 'pool' is used to denote that a
+``/etc/synnefo/20-snf-cyclades-app-api.conf``. ``pool`` is used to denote that a
 link or MAC prefix will be allocated from the corresponding Pool. Finally,
 most of these attributes, may be overridden when creating networks with
 `snf-manage network-create command`.
@@ -258,7 +258,7 @@ issuing:
 
    # gnt-network add --network=5.6.7.0/27 --gateway=5.6.7.1 --network6=2001:648:2FFC:1322::/64 --gateway6=2001:648:2FFC:1322::1 --network-type=public --tags=nfdhcpd snf-net-1
 
-   # gnt-network connect snf-net-1 default bridged br100
+   # gnt-network connect --nic-parameters mode=bridged,link=br100 snf-net-1
    # gnt-network list snf-net-1
    Network   Subnet     Gateway NetworkType MacPrefix GroupList               Tags
    snf-net-1 5.6.7.0/27 5.6.7.1 public      None      default(bridged, br100) nfdhcpd
@@ -313,7 +313,7 @@ issuing:
 
    # gnt-network add --network=5.6.7.0/27 --gateway=5.6.7.1 --network6=2001:648:2FFC:1322::/64 --gateway6=2001:648:2FFC:1322::1  --network-type=public  --tags=nfdhcpd,ip-less-routed  snf-net-2
 
-   # gnt-network connect snf-net-2 default bridged br100
+   # gnt-network connect --nic-parameters mode=bridged,link=br100 snf-net-2
    # gnt-network list snf-net-2
    Network      Subnet            Gateway        NetworkType MacPrefix GroupList                   Tags
    dimara-net-1 62.217.123.128/27 62.217.123.129 public      None      default(routed, snf_public) nfdhcpd,ip-less-routed
@@ -370,7 +370,7 @@ issuing:
 
    # gnt-network add --network=192.168.1.0/24  --gateway=192.168.1.1  --network-type=private  --tags=nfdhcpd,private-filtered snf-net-3
 
-   # gnt-network connect snf-net-3 default bridged prv0
+   # gnt-network connect --nic-parameters mode=bridged,link=prv0 snf-net-3
    # gnt-network list snf-net-3
    Network   Subnet         Gateway     NetworkType MacPrefix GroupList               Tags
    snf-net-3 192.168.1.0/24 192.168.1.1 private     aa:00:01  default(bridged, prv0) nfdhcpd,private-filtered
@@ -432,7 +432,7 @@ issuing:
 
    # gnt-network add --network=192.168.1.0/24 --gateway=192.168.1.1 --network-type=private --tags=nfdhcpd,physica-vlan snf-net-4
 
-   # gnt-network connect snf-net-4 default bridged prv1
+   # gnt-network connect --nic-parameters mode=bridged,link=prv1 snf-net-4
    # gnt-network list snf-net-4
    Network   Subnet         Gateway     NetworkType MacPrefix GroupList               Tags
    snf-net-4 192.168.1.0/24 192.168.1.1 private     None      default(bridged, prv1)  nfdhcpd,physical-vlan
@@ -466,7 +466,7 @@ issuing:
 
    # gnt-network add --network=192.168.1.0/24 --gateway=192.168.1.1 --network-type=private --tags=nfdhcpd snf-net-5
 
-   # gnt-network connect snf-net-5 default bridged br200
+   # gnt-network connect --nic-parameters mode=bridged,link=br200 snf-net-5
    # gnt-network list snf-net-5
    Network   Subnet         Gateway     NetworkType MacPrefix GroupList               Tags
    snf-net-5 192.168.1.0/24 192.168.1.1 private     bb:00:55  default(bridged, br200) nfdhcpd,private-filtered


### PR DESCRIPTION
The syntax of `gnt-network connect` command changed recently. This
commit updates networks.rst and the installation guides to comply with
the new syntax.
