### PR TITLE
webproject: Extend allocated xseg pool array

### DIFF
--- a/snf-webproject/conf/gunicorn-hooks/gunicorn-archipelago.py
+++ b/snf-webproject/conf/gunicorn-hooks/gunicorn-archipelago.py
@@ -48,6 +48,7 @@ def follow_workers(pid, wid, server):
         k = {pid: int(hole[0])}
     else:
         k = {pid: wid}
+        hole.append(wid)
     f.update(k)
     fd.seek(0)
     pickle.dump(f, fd)
@@ -100,9 +101,4 @@ def worker_exit(server, worker):
 
 def on_exit(server):
     server.state_fd.close()
-
-
-def on_reload(server):
-    server.worker_age = 0
-
 # vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4


### PR DESCRIPTION
On gunicorn reload extend allocated xseg pool per worker class
array until the already spawned workers exit. On a graceful worker
exit the previously allocated xseg pool is properly shutdown and
the new workers takeover the next series of xseg ports.
On a next reload basis the new workers will always take over the
previously allocated xseg pool ports. With this mechanism we always
need at least twice the number of workers in xseg ports per pool.

Care must be taken in xseg ports accounting and bookkeeping when
we dynamically change the number of workers by using the TTIN and
TTOUT signals sent to the master.

The total number of xseg ports allocated by all workers must not
exceed the minimum port being used by the Archipelago peers.
If the total amount of used ports exceeds this limit one should
rearrange the Archipelago peers ports along with the relevant
dynamic port range.
