### PR TITLE
ui: Set autofocus to astakos login first input

### DIFF
--- a/snf-astakos-app/astakos/im/forms.py
+++ b/snf-astakos-app/astakos/im/forms.py
@@ -246,9 +246,10 @@ class ThirdPartyUserCreationForm(forms.ModelForm):
         pending.delete()
         return user
 
+autofocus_widget = forms.TextInput(attrs={'autofocus': 'autofocus'})
 
 class LoginForm(AuthenticationForm):
-    username = EmailField(label=_("Email"))
+    username = EmailField(label=_("Email"), widget=autofocus_widget)
     recaptcha_challenge_field = forms.CharField(widget=DummyWidget)
     recaptcha_response_field = forms.CharField(
         widget=RecaptchaWidget, label='')


### PR DESCRIPTION
Use HTML5 `autofocus` input attribute to set focus automatically to the email input field in local login form when the page loads.
Browser support:

| IE	| FIREFOX	| SAFARI | CHROME | OPERA | IPHONE |ANDROID |
| ------------- |:-------------:| -----:| -----:| -----:| -----:| -----:|
| 10.0+ | 4.0+ |	4.0+ | 3.0+ | 10.0+ | - | 3.0+ |

Browsers that don’t support the autofocus attribute will simply ignore it.
@vinilios 