### PR TITLE
Corrects the example about the SOFT reboot

### DIFF
--- a/docs/compute-api-guide.rst
+++ b/docs/compute-api-guide.rst
@@ -1683,11 +1683,11 @@ Request body contents::
 
 * **reboot type** can be either ``SOFT`` or ``HARD``.
 
-*Example (soft) Reboot Server: JSON*
+*Example (SOFT) Reboot Server: JSON*
 
 .. code-block:: javascript
 
-  {"reboot" : { "type": "soft"}}
+  {"reboot" : { "type": "SOFT"}}
 
 Resize Server
 .............


### PR DESCRIPTION
As described a few lines above, the reboot type can either be
```SOFT``` or ```HARD``` and not ```soft``` or ```hard```