### PR TITLE
admin: Fetch Image info using uuid and version

### DIFF
--- a/snf-admin-app/synnefo_admin/admin/templatetags/admin_tags.py
+++ b/snf-admin-app/synnefo_admin/admin/templatetags/admin_tags.py
@@ -156,7 +156,8 @@ def image_info(vm):
 
     # Check if Cyclades DB has any info about this Image.
     try:
-        image_info = Image.objects.get(uuid=vm.imageid)
+        image_info = Image.objects.get(uuid=vm.imageid,
+                                       version=vm.image_version)
     except ObjectDoesNotExist:
         # If all else fails, gather whatever info are available from the
         # VirtualMachine instance.


### PR DESCRIPTION
When attempting to read Image info about a VM, use both the image id and
version that are stored in the VM.

Fix apyrgio/synnefo#331