### PR TITLE
debian: Use the proper snf-dispatcher script

### DIFF
--- a/debian/snf-cyclades-app.snf-dispatcher.init
+++ b/debian/snf-cyclades-app.snf-dispatcher.init
@@ -16,7 +16,7 @@
 
 # /etc/init.d/snf-dispatcher: start and stop the dispatcher daemon
 
-DAEMON=/usr/bin/snf-dispatcher
+DAEMON=$(which snf-dispatcher)
 NAME="snf-dispatcher"
 DESCRIPTION="Synnefo Dispatcher Daemon"
 DAEMON_OPTS=''


### PR DESCRIPTION
Get the proper snf-dispatcher script via `$(which snf-dispatcher)`.
Using statically the /usr/bin/snf-dispatcher script does not work for
development.