### PR TITLE
pithos: Add a new setting for block module arguments

### DIFF
--- a/snf-cyclades-app/conf/20-snf-cyclades-app-plankton.conf
+++ b/snf-cyclades-app/conf/20-snf-cyclades-app-plankton.conf
@@ -7,6 +7,10 @@
 #BACKEND_DB_CONNECTION = 'sqlite:////usr/share/synnefo/pithos/backend.db'
 #PITHOS_BACKEND_POOL_SIZE = 8
 #
+## Backend block module settings
+#PITHOS_BACKEND_BLOCK_MODULE = 'pithos.backends.lib.hashfiler'
+#PITHOS_BACKEND_BLOCK_KWARGS = {}
+#
 ## The Pithos container where images will be stored by default
 #DEFAULT_PLANKTON_CONTAINER = 'images'
 #

--- a/snf-cyclades-app/synnefo/app_settings/default/plankton.py
+++ b/snf-cyclades-app/synnefo/app_settings/default/plankton.py
@@ -7,6 +7,10 @@
 BACKEND_DB_CONNECTION = 'sqlite:////usr/share/synnefo/pithos/backend.db'
 PITHOS_BACKEND_POOL_SIZE = 8
 
+# Backend block module settings
+PITHOS_BACKEND_BLOCK_MODULE = 'pithos.backends.lib.hashfiler'
+PITHOS_BACKEND_BLOCK_KWARGS = {}
+
 # The Pithos container where images will be stored by default
 DEFAULT_PLANKTON_CONTAINER = 'images'
 

--- a/snf-cyclades-app/synnefo/plankton/backend.py
+++ b/snf-cyclades-app/synnefo/plankton/backend.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -80,6 +80,8 @@ def get_pithos_backend():
             astakos_auth_url=settings.ASTAKOS_AUTH_URL,
             service_token=settings.CYCLADES_SERVICE_TOKEN,
             astakosclient_poolsize=settings.CYCLADES_ASTAKOSCLIENT_POOLSIZE,
+            block_module=settings.PITHOS_BACKEND_BLOCK_MODULE,
+            block_params=settings.PITHOS_BACKEND_BLOCK_KWARGS,
             db_connection=settings.BACKEND_DB_CONNECTION,
             archipelago_conf_file=settings.PITHOS_BACKEND_ARCHIPELAGO_CONF,
             xseg_pool_size=settings.PITHOS_BACKEND_XSEG_POOL_SIZE,

--- a/snf-pithos-app/conf/20-snf-pithos-app-settings.conf
+++ b/snf-pithos-app/conf/20-snf-pithos-app-settings.conf
@@ -10,8 +10,10 @@
 #PITHOS_BACKEND_DB_MODULE = 'pithos.backends.lib.sqlalchemy'
 #PITHOS_BACKEND_DB_CONNECTION = 'sqlite:////tmp/pithos-backend.db'
 
-# Block storage.
+# Block storage module
 #PITHOS_BACKEND_BLOCK_MODULE = 'pithos.backends.lib.hashfiler'
+# Arguments for block storage module
+#PITHOS_BACKEND_BLOCK_KWARGS = {}
 
 # Default setting for new accounts.
 #PITHOS_BACKEND_VERSIONING = 'auto'

--- a/snf-pithos-app/pithos/api/settings.py
+++ b/snf-pithos-app/pithos/api/settings.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -118,6 +118,7 @@ BACKEND_BLOCK_MODULE = getattr(
 BACKEND_BLOCK_PATH = getattr(
     settings, 'PITHOS_BACKEND_BLOCK_PATH', '/tmp/pithos-data/')
 BACKEND_BLOCK_UMASK = getattr(settings, 'PITHOS_BACKEND_BLOCK_UMASK', 0o022)
+BACKEND_BLOCK_KWARGS = getattr(settings, 'PITHOS_BACKEND_BLOCK_KWARGS', {})
 
 
 # Default setting for new accounts.
@@ -137,10 +138,6 @@ BACKEND_POOL_SIZE = getattr(settings, 'PITHOS_BACKEND_POOL_SIZE', 5)
 
 # Update object checksums.
 UPDATE_MD5 = getattr(settings, 'PITHOS_UPDATE_MD5', False)
-
-RADOS_STORAGE = getattr(settings, 'PITHOS_RADOS_STORAGE', False)
-RADOS_POOL_BLOCKS = getattr(settings, 'PITHOS_RADOS_POOL_BLOCKS', 'blocks')
-RADOS_POOL_MAPS = getattr(settings, 'PITHOS_RADOS_POOL_MAPS', 'maps')
 
 # This enables a ui compatibility layer for the introduction of UUIDs in
 # identity management.  WARNING: Setting to True will break your installation.

--- a/snf-pithos-app/pithos/api/util.py
+++ b/snf-pithos-app/pithos/api/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,7 +37,7 @@ from snf_django.lib import api
 from snf_django.lib.api import faults, utils
 
 from pithos.api.settings import (BACKEND_DB_MODULE, BACKEND_DB_CONNECTION,
-                                 BACKEND_BLOCK_MODULE,
+                                 BACKEND_BLOCK_MODULE, BACKEND_BLOCK_KWARGS,
                                  ASTAKOSCLIENT_POOLSIZE,
                                  SERVICE_TOKEN,
                                  ASTAKOS_AUTH_URL,
@@ -50,8 +50,7 @@ from pithos.api.settings import (BACKEND_DB_MODULE, BACKEND_DB_CONNECTION,
                                  BACKEND_XSEG_POOL_SIZE,
                                  BACKEND_MAP_CHECK_INTERVAL,
                                  BACKEND_MAPFILE_PREFIX,
-                                 RADOS_STORAGE, RADOS_POOL_BLOCKS,
-                                 RADOS_POOL_MAPS, TRANSLATE_UUIDS,
+                                 TRANSLATE_UUIDS,
                                  PUBLIC_URL_SECURITY, PUBLIC_URL_ALPHABET,
                                  BASE_HOST, UPDATE_MD5, VIEW_PREFIX,
                                  OAUTH2_CLIENT_CREDENTIALS, UNSAFE_DOMAIN,
@@ -999,13 +998,6 @@ def simple_list_response(request, l):
 
 from pithos.backends.util import PithosBackendPool
 
-if RADOS_STORAGE:
-    BLOCK_PARAMS = {'mappool': RADOS_POOL_MAPS,
-                    'blockpool': RADOS_POOL_BLOCKS, }
-else:
-    BLOCK_PARAMS = {'mappool': None,
-                    'blockpool': None, }
-
 BACKEND_KWARGS = dict(
     db_module=BACKEND_DB_MODULE,
     db_connection=BACKEND_DB_CONNECTION,
@@ -1016,7 +1008,7 @@ BACKEND_KWARGS = dict(
     service_token=SERVICE_TOKEN,
     astakosclient_poolsize=ASTAKOSCLIENT_POOLSIZE,
     free_versioning=BACKEND_FREE_VERSIONING,
-    block_params=BLOCK_PARAMS,
+    block_params=BACKEND_BLOCK_KWARGS,
     public_url_security=PUBLIC_URL_SECURITY,
     public_url_alphabet=PUBLIC_URL_ALPHABET,
     account_quota_policy=BACKEND_ACCOUNT_QUOTA,

--- a/snf-pithos-backend/pithos/backends/lib/hashfiler/archipelagoblocker.py
+++ b/snf-pithos-backend/pithos/backends/lib/hashfiler/archipelagoblocker.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,7 +38,6 @@ class ArchipelagoBlocker(object):
     """
 
     blocksize = None
-    blockpool = None
     hashtype = None
 
     def __init__(self, **params):

--- a/snf-pithos-backend/pithos/backends/lib/hashfiler/blocker.py
+++ b/snf-pithos-backend/pithos/backends/lib/hashfiler/blocker.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@ from archipelagoblocker import ArchipelagoBlocker
 class Blocker(object):
     """Blocker.
        Required constructor parameters: blocksize, blockpath, hashtype.
-       Optional blockpool.
     """
 
     def __init__(self, **params):

--- a/snf-pithos-backend/pithos/backends/lib/hashfiler/mapper.py
+++ b/snf-pithos-backend/pithos/backends/lib/hashfiler/mapper.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,8 +18,7 @@ from archipelagomapper import ArchipelagoMapper
 
 class Mapper(object):
     """Mapper.
-       Required constructor parameters: mappath, namelen.
-       Optional mappool.
+       Required constructor parameters: namelen.
     """
 
     def __init__(self, **params):

--- a/snf-pithos-backend/pithos/backends/lib/hashfiler/store.py
+++ b/snf-pithos-backend/pithos/backends/lib/hashfiler/store.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,8 +19,8 @@ from mapper import Mapper
 
 class Store(object):
     """Store.
-       Required constructor parameters: path, block_size, hash_algorithm,
-       blockpool, mappool.
+       Required constructor parameters: block_size, hash_algorithm,
+                                        archipelago_cfile, namelen
     """
 
     def __init__(self, **params):

--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,7 +87,6 @@ DEFAULT_DB_CONNECTION = 'sqlite:///backend.db'
 DEFAULT_BLOCK_MODULE = 'pithos.backends.lib.hashfiler'
 DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024  # 4MB
 DEFAULT_HASH_ALGORITHM = 'sha256'
-DEFAULT_BLOCK_PARAMS = {'mappool': None, 'blockpool': None}
 
 # Default setting for new accounts.
 DEFAULT_ACCOUNT_QUOTA = 0  # No quota.
@@ -236,7 +235,7 @@ class ModularBackend(object):
                  service_token=None,
                  astakosclient_poolsize=None,
                  free_versioning=True,
-                 block_params=DEFAULT_BLOCK_PARAMS,
+                 block_params=None,
                  public_url_security=DEFAULT_PUBLIC_URL_SECURITY,
                  public_url_alphabet=DEFAULT_PUBLIC_URL_ALPHABET,
                  account_quota_policy=DEFAULT_ACCOUNT_QUOTA,
@@ -250,7 +249,7 @@ class ModularBackend(object):
                  acc_max_groups=DEFAULT_ACC_MAX_GROUPS,
                  acc_max_group_members=DEFAULT_ACC_MAX_GROUP_MEMBERS):
 
-        not_nullable = ('block_size', 'hash_algorithm', 'block_params',
+        not_nullable = ('block_size', 'hash_algorithm',
                         'public_url_security', 'public_url_alphabet',
                         'account_quota_policy', 'container_versioning_policy',
                         'archipelago_conf_file', 'xseg_pool_size',
@@ -314,7 +313,8 @@ class ModularBackend(object):
         params = {'block_size': self.block_size,
                   'hash_algorithm': self.hash_algorithm,
                   'archipelago_cfile': archipelago_conf_file}
-        params.update(self.block_params)
+        if block_params is not None:
+            params.update(block_params)
         self.store = self.block_module.Store(**params)
 
         self.astakos_auth_url = astakos_auth_url


### PR DESCRIPTION
Add the new PITHOS_BACKEND_BLOCK_KWARGS setting that can be used to pass
keyword arguments to the Pithos backend block module. This setting
replaces the obsolete RADOS_STORAGE, RADOS_POOL_BLOCKS and
RADOS_POOL_MAPS setting. Also, fix some comments.
