### PR TITLE
Some patches for pithos, deploy, and burnin

### DIFF
--- a/snf-deploy/conf/nodes.conf
+++ b/snf-deploy/conf/nodes.conf
@@ -6,6 +6,9 @@
 # Instances will reside in the .vm.<domain> subdomain
 domain = synnefo.live
 
+# This is the default forwarder to be used by bind
+nameserver = 8.8.8.8
+
 # Each node should define:
 
 # The node's desired hostname. It will be set

--- a/snf-deploy/files/etc/bind/named.conf.options
+++ b/snf-deploy/files/etc/bind/named.conf.options
@@ -10,9 +10,9 @@ options {
         // Uncomment the following block, and insert the addresses replacing
         // the all-0's placeholder.
 
-        // forwarders {
-        //      0.0.0.0;
-        // };
+        forwarders {
+             %NAMESERVERS%;
+        };
 
         auth-nxdomain no;    # conform to RFC1035
         allow-recursion { %NODE_IPS%; };

--- a/snf-deploy/snfdeploy/components.py
+++ b/snf-deploy/snfdeploy/components.py
@@ -773,9 +773,12 @@ gnt-cluster init --enabled-hypervisors=kvm \
     --ipolicy-std-specs {2} \
     --ipolicy-bounds-specs min:{3}/max:{4} \
     --enabled-disk-templates file,ext \
-    {5}
+    --file-storage-dir {5}/ganeti/file-storage \
+    --shared-file-storage-dir {5}/ganeti/shared-file-storage \
+    {6}
         """.format(config.common_bridge, self.cluster.netdev,
-                   std, bound_min, bound_max, self.cluster.fqdn)
+                   std, bound_min, bound_max, config.shared_dir,
+                   self.cluster.fqdn)
 
         modify = "gnt-node modify --vm-capable=no %s" % self.node.fqdn
 

--- a/snf-deploy/snfdeploy/components.py
+++ b/snf-deploy/snfdeploy/components.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2015 GRNET S.A. and individual contributors
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -192,6 +192,9 @@ class HW(base.Component):
 class SSH(base.Component):
     @base.run_cmds
     def prepare(self):
+        if not config.key_inject:
+            return []
+
         return [
             "mkdir -p /root/.ssh",
             "for f in $(ls /root/.ssh/*); do cp $f $f.bak ; done",
@@ -199,6 +202,9 @@ class SSH(base.Component):
             ]
 
     def _configure(self):
+        if not config.key_inject:
+            return []
+
         files = [
             "authorized_keys", "id_dsa", "id_dsa.pub", "id_rsa", "id_rsa.pub"
             ]
@@ -207,6 +213,9 @@ class SSH(base.Component):
 
     @base.run_cmds
     def initialize(self):
+        if not config.key_inject:
+            return []
+
         f = "/root/.ssh/authorized_keys"
         return [
             "test -e {0}.bak && cat {0}.bak >> {0} || true".format(f)

--- a/snf-deploy/snfdeploy/components.py
+++ b/snf-deploy/snfdeploy/components.py
@@ -333,6 +333,10 @@ EOF
     def _configure(self):
         d = self.node.domain
         ip = self.node.ip
+        r1 = {
+            "node_ips": ";".join(self.ctx.all_ips),
+            "nameservers": ";".join(self.ctx.all_nameservers),
+            }
         return [
             ("/etc/bind/named.conf.local", {"domain": d}, {}),
             ("/etc/bind/zones/example.com",
@@ -343,8 +347,7 @@ EOF
              {"remote": "/etc/bind/zones/vm.%s" % d}),
             ("/etc/bind/rev/synnefo.in-addr.arpa.zone", {"domain": d}, {}),
             ("/etc/bind/rev/synnefo.ip6.arpa.zone", {"domain": d}, {}),
-            ("/etc/bind/named.conf.options",
-             {"node_ips": ";".join(self.ctx.all_ips)}, {}),
+            ("/etc/bind/named.conf.options", r1, {}),
             ("/root/ddns/ddns.key", {}, {"remote": "/etc/bind/ddns.key"}),
             ]
 

--- a/snf-deploy/snfdeploy/components.py
+++ b/snf-deploy/snfdeploy/components.py
@@ -527,7 +527,9 @@ class LVM(base.Component):
         # If extra disk found use it
         # else create a raw file and losetup it
         cmd = """
-if [ -b "{0}" ]; then
+if vgs {2}; then
+  echo "VG ${2} found!"
+elif [ -b "{0}" ]; then
   pvcreate {0} && vgcreate {2} {0}
 else
   truncate -s {3} {1}

--- a/snf-deploy/snfdeploy/config.py
+++ b/snf-deploy/snfdeploy/config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -136,6 +136,7 @@ def init(args):
     config.dry_run = args.dry_run
     config.force = args.force
     config.ssh_key = args.ssh_key
+    config.key_inject = args.key_inject
     config.mem = args.mem
     config.vnc = args.vnc
     config.smp = args.smp

--- a/snf-deploy/snfdeploy/context.py
+++ b/snf-deploy/snfdeploy/context.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -118,6 +118,11 @@ class Context(object):
     def all_ips(self):
         l = lambda x: config.get_node_info(x).ip
         return [l(n) for n in self.all_nodes]
+
+    @property
+    def all_nameservers(self):
+        l = lambda x: config.get_node_info(x).nameserver
+        return set([l(n) for n in self.all_nodes])
 
     def get(self, role):
         try:

--- a/snf-pithos-app/conf/20-snf-pithos-app-settings.conf
+++ b/snf-pithos-app/conf/20-snf-pithos-app-settings.conf
@@ -69,6 +69,13 @@
 #
 # The maximum interval (in seconds) for consequent backend object map checks
 #PITHOS_BACKEND_MAP_CHECK_INTERVAL = 1
+#
+# Enable deletion of mapfiles after deleting a version of some object.
+# This is option is *unsafe* for installatioins prior to Synnefo version
+# 0.16rc1 (commit 13d49ad) which may still include Markle-hashes and not
+# Archipelago mapfiles in Pithos database.
+#PITHOS_BACKEND_PURGE_MAPFILES = False
+#
 # The archipelago mapfile prefix (it should not exceed 15 characters)
 # WARNING: Once set it should not be changed
 #PITHOS_BACKEND_MAPFILE_PREFIX='snf_file_'

--- a/snf-pithos-app/pithos/api/settings.py
+++ b/snf-pithos-app/pithos/api/settings.py
@@ -185,6 +185,10 @@ BACKEND_XSEG_POOL_SIZE = getattr(settings, 'PITHOS_BACKEND_XSEG_POOL_SIZE', 8)
 BACKEND_MAP_CHECK_INTERVAL = getattr(settings,
                                      'PITHOS_BACKEND_MAP_CHECK_INTERVAL', 5)
 
+# Whether to delete mapfiles or not
+BACKEND_PURGE_MAPFILES = getattr(settings, 'PITHOS_BACKEND_PURGE_MAPFILES',
+                                 False)
+
 # The archipelago mapfile prefix (it should not exceed 15 characters)
 # WARNING: Once set it should not be changed
 BACKEND_MAPFILE_PREFIX = getattr(settings,

--- a/snf-pithos-app/pithos/api/util.py
+++ b/snf-pithos-app/pithos/api/util.py
@@ -38,6 +38,7 @@ from snf_django.lib.api import faults, utils
 
 from pithos.api.settings import (BACKEND_DB_MODULE, BACKEND_DB_CONNECTION,
                                  BACKEND_BLOCK_MODULE, BACKEND_BLOCK_KWARGS,
+                                 BACKEND_PURGE_MAPFILES,
                                  ASTAKOSCLIENT_POOLSIZE,
                                  SERVICE_TOKEN,
                                  ASTAKOS_AUTH_URL,
@@ -1008,6 +1009,7 @@ BACKEND_KWARGS = dict(
     service_token=SERVICE_TOKEN,
     astakosclient_poolsize=ASTAKOSCLIENT_POOLSIZE,
     free_versioning=BACKEND_FREE_VERSIONING,
+    purge_mapfiles=BACKEND_PURGE_MAPFILES,
     block_params=BACKEND_BLOCK_KWARGS,
     public_url_security=PUBLIC_URL_SECURITY,
     public_url_alphabet=PUBLIC_URL_ALPHABET,

--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -235,6 +235,7 @@ class ModularBackend(object):
                  service_token=None,
                  astakosclient_poolsize=None,
                  free_versioning=True,
+                 purge_mapfiles=False,
                  block_params=None,
                  public_url_security=DEFAULT_PUBLIC_URL_SECURITY,
                  public_url_alphabet=DEFAULT_PUBLIC_URL_ALPHABET,
@@ -275,6 +276,7 @@ class ModularBackend(object):
         self.hash_algorithm = hash_algorithm
         self.block_size = block_size
         self.free_versioning = free_versioning
+        self.purge_mapfiles = purge_mapfiles
         self.map_check_interval = map_check_interval
         self.mapfile_prefix = mapfile_prefix
         self.resource_max_metadata = resource_max_metadata
@@ -769,7 +771,8 @@ class ModularBackend(object):
             if versioning != 'auto':
                 _ , _, mapfile = self.node.version_remove(
                     src_version_id, update_statistics_ancestors_depth=0)
-                self.store.map_delete(mapfile)
+                if self.purge_mapfiles:
+                    self.store.map_delete(mapfile)
 
     @debug_method
     @backend_method
@@ -876,8 +879,9 @@ class ModularBackend(object):
             _, size, _, mapfiles = self.node.node_purge_children(
                 node, until, CLUSTER_HISTORY,
                 update_statistics_ancestors_depth=0)
-            for m in mapfiles:
-                self.store.map_delete(m)
+            if self.purge_mapfiles:
+                for m in mapfiles:
+                    self.store.map_delete(m)
             self.node.node_purge_children(node, until, CLUSTER_DELETED,
                                           update_statistics_ancestors_depth=0)
             if not self.free_versioning:
@@ -891,8 +895,9 @@ class ModularBackend(object):
             _, size, _, mapfiles = self.node.node_purge_children(
                 node, inf, CLUSTER_HISTORY,
                 update_statistics_ancestors_depth=0)
-            for m in mapfiles:
-                self.store.map_delete(m)
+            if self.purge_mapfiles:
+                for m in mapfiles:
+                    self.store.map_delete(m)
             self.node.node_purge_children(node, inf, CLUSTER_DELETED,
                                           update_statistics_ancestors_depth=0)
             self.node.node_remove(node, update_statistics_ancestors_depth=0)
@@ -1877,8 +1882,9 @@ class ModularBackend(object):
             mapfiles.extend(m)
             if not self.free_versioning:
                 size += s
-            for m in mapfiles:
-                self.store.map_delete(m)
+            if self.purge_mapfiles:
+                for m in mapfiles:
+                    self.store.map_delete(m)
 
             self.node.node_purge(node, until, CLUSTER_DELETED,
                                  update_statistics_ancestors_depth=1)
@@ -2481,7 +2487,8 @@ class ModularBackend(object):
         if versioning != 'auto':
             _, size, mapfile = self.node.version_remove(
                 version_id, update_statistics_ancestors_depth)
-            self.store.map_delete(mapfile)
+            if self.purge_mapfiles:
+                self.store.map_delete(mapfile)
             return size
         elif self.free_versioning:
             return self.node.version_get_properties(

--- a/snf-pithos-backend/pithos/backends/modular.py
+++ b/snf-pithos-backend/pithos/backends/modular.py
@@ -767,8 +767,9 @@ class ModularBackend(object):
             versioning = self._get_policy(
                 node, is_account_policy=False)[VERSIONING_POLICY]
             if versioning != 'auto':
-                self.node.version_remove(src_version_id,
-                                         update_statistics_ancestors_depth=0)
+                _ , _, mapfile = self.node.version_remove(
+                    src_version_id, update_statistics_ancestors_depth=0)
+                self.store.map_delete(mapfile)
 
     @debug_method
     @backend_method
@@ -872,11 +873,11 @@ class ModularBackend(object):
         project = self._get_project(node)
 
         if until is not None:
-            hashes, size, _ = self.node.node_purge_children(
+            _, size, _, mapfiles = self.node.node_purge_children(
                 node, until, CLUSTER_HISTORY,
                 update_statistics_ancestors_depth=0)
-            for h in hashes:
-                self.store.map_delete(h)
+            for m in mapfiles:
+                self.store.map_delete(m)
             self.node.node_purge_children(node, until, CLUSTER_DELETED,
                                           update_statistics_ancestors_depth=0)
             if not self.free_versioning:
@@ -887,11 +888,11 @@ class ModularBackend(object):
         if not delimiter:
             if self._get_statistics(node)[0] > 0:
                 raise ContainerNotEmpty("Container is not empty")
-            hashes, size, _ = self.node.node_purge_children(
+            _, size, _, mapfiles = self.node.node_purge_children(
                 node, inf, CLUSTER_HISTORY,
                 update_statistics_ancestors_depth=0)
-            for h in hashes:
-                self.store.map_delete(h)
+            for m in mapfiles:
+                self.store.map_delete(m)
             self.node.node_purge_children(node, inf, CLUSTER_DELETED,
                                           update_statistics_ancestors_depth=0)
             self.node.node_remove(node, update_statistics_ancestors_depth=0)
@@ -1863,19 +1864,22 @@ class ModularBackend(object):
         if until is not None:
             if node is None:
                 return
-            hashes = []
             size = 0
-            h, s, _ = self.node.node_purge(node, until, CLUSTER_NORMAL,
-                                           update_statistics_ancestors_depth=1)
-            hashes += h
+            mapfiles = []
+            _, s, _, m = self.node.node_purge(
+                node, until, CLUSTER_NORMAL,
+                update_statistics_ancestors_depth=1)
             size += s
-            h, s, _ = self.node.node_purge(node, until, CLUSTER_HISTORY,
-                                           update_statistics_ancestors_depth=1)
-            hashes += h
+            mapfiles.extend(m)
+            _, s, _, m = self.node.node_purge(
+                node, until, CLUSTER_HISTORY,
+                update_statistics_ancestors_depth=1)
+            mapfiles.extend(m)
             if not self.free_versioning:
                 size += s
-            for h in hashes:
-                self.store.map_delete(h)
+            for m in mapfiles:
+                self.store.map_delete(m)
+
             self.node.node_purge(node, until, CLUSTER_DELETED,
                                  update_statistics_ancestors_depth=1)
             try:
@@ -1891,7 +1895,7 @@ class ModularBackend(object):
 
         # keep reference to the mapfile
         # in case we will want to delete them in the future
-        src_version_id, dest_version_id, _ = self._put_version_duplicate(
+        src_version_id, dest_version_id, mapfile = self._put_version_duplicate(
             user, node, size=0, type='', hash=None, checksum='',
             cluster=CLUSTER_DELETED, update_statistics_ancestors_depth=1,
             keep_src_mapfile=True)
@@ -2475,9 +2479,9 @@ class ModularBackend(object):
         versioning = self._get_policy(
             node, is_account_policy=False)[VERSIONING_POLICY]
         if versioning != 'auto':
-            hash, size = self.node.version_remove(
+            _, size, mapfile = self.node.version_remove(
                 version_id, update_statistics_ancestors_depth)
-            self.store.map_delete(hash)
+            self.store.map_delete(mapfile)
             return size
         elif self.free_versioning:
             return self.node.version_get_properties(

--- a/snf-pithos-backend/pithos/backends/util.py
+++ b/snf-pithos-backend/pithos/backends/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2014 GRNET S.A.
+# Copyright (C) 2010-2016 GRNET S.A. and individual contributors
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,11 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
+
 from objpool import ObjectPool
 from new import instancemethod
 from select import select
 from traceback import print_exc
 from pithos.backends import connect_backend
+
+log = logging.getLogger(__name__)
 
 USAGE_LIMIT = 500
 
@@ -25,9 +29,11 @@ USAGE_LIMIT = 500
 class PithosBackendPool(ObjectPool):
     def __init__(self, size=None, **kwargs):
         super(PithosBackendPool, self).__init__(size=size)
+        log.debug("Initializing PithosBackendPool")
         self.backend_kwargs = kwargs
 
     def _pool_create(self):
+        log.debug("Creating pool")
         backend = connect_backend(**self.backend_kwargs)
         backend._real_close = backend.close
         backend.close = instancemethod(_pooled_backend_close, backend,
@@ -38,6 +44,7 @@ class PithosBackendPool(ObjectPool):
         return backend
 
     def _pool_verify(self, backend):
+        log.debug("Verifying pool %s", backend)
         wrapper = backend.wrapper
         conn = wrapper.conn
         if conn.closed:
@@ -62,9 +69,11 @@ class PithosBackendPool(ObjectPool):
                 print_exc()
                 return False
 
+        log.debug("Pool %s ok", backend)
         return True
 
     def _pool_cleanup(self, backend):
+        log.debug("Cleaning up pool %s", backend)
         c = backend._use_count - 1
         if c < 0:
             backend._real_close()
@@ -84,6 +93,7 @@ class PithosBackendPool(ObjectPool):
     def shutdown(self):
         while True:
             backend = self.pool_get(create=False)
+            log.debug("Shutting down pool %s", backend)
             if backend is None:
                 break
             self.pool_put(None)
@@ -91,4 +101,5 @@ class PithosBackendPool(ObjectPool):
 
 
 def _pooled_backend_close(backend):
+    log.debug("Closing pool %s", backend)
     backend._pool.pool_put(backend)

--- a/snf-tools/synnefo_tools/burnin/__init__.py
+++ b/snf-tools/synnefo_tools/burnin/__init__.py
@@ -149,6 +149,10 @@ def parse_arguments(args):
         type="string", default="/var/log/burnin/", dest="log_folder",
         help="Define the absolute path where the output log is stored")
     parser.add_option(
+        "--state-folder", action="store",
+        type="string", default="/var/lib/burnin/", dest="state_folder",
+        help="Define the absolute path where various test data is stored")
+    parser.add_option(
         "--verbose", "-v", action="store",
         type="int", default=1, dest="verbose",
         help="Print detailed output messages")

--- a/snf-tools/synnefo_tools/burnin/common.py
+++ b/snf-tools/synnefo_tools/burnin/common.py
@@ -764,7 +764,7 @@ class BurninTests(unittest.TestCase):
 
 # --------------------------------------------------------------------
 # Initialize Burnin
-def initialize(opts, testsuites, stale_testsuites):
+def initialize(opts):
     """Initalize burnin
 
     Initialize our logger and burnin state
@@ -807,19 +807,6 @@ def initialize(opts, testsuites, stale_testsuites):
 
     BurninTests.state_dir = state_dir
     BurninTests.run_id = run_id
-
-    # Choose tests to run
-    if opts.show_stale:
-        # We will run the stale_testsuites
-        return (stale_testsuites, True)
-
-    if opts.tests != "all":
-        testsuites = opts.tests
-    if opts.exclude_tests is not None:
-        testsuites = [tsuite for tsuite in testsuites
-                      if tsuite not in opts.exclude_tests]
-
-    return (testsuites, opts.failfast)
 
 
 # --------------------------------------------------------------------

--- a/snf-tools/synnefo_tools/burnin/common.py
+++ b/snf-tools/synnefo_tools/burnin/common.py
@@ -18,6 +18,7 @@ Common utils for burnin tests
 
 """
 
+import os
 import hashlib
 import re
 import shutil
@@ -792,11 +793,20 @@ def initialize(opts, testsuites, stale_testsuites):
     BurninTests.delete_stale = opts.delete_stale
     BurninTests.temp_directory = opts.temp_directory
     BurninTests.failfast = opts.failfast
-    BurninTests.run_id = SNF_TEST_PREFIX + \
-        datetime.datetime.strftime(curr_time, "%Y%m%d%H%M%S")
     BurninTests.obj_upload_num = opts.obj_upload_num
     BurninTests.obj_upload_min_size = opts.obj_upload_min_size
     BurninTests.obj_upload_max_size = opts.obj_upload_max_size
+
+    run_id = SNF_TEST_PREFIX + \
+        datetime.datetime.strftime(curr_time, "%Y%m%d%H%M%S")
+
+    # Do not create the state dir yet.
+    # Let the test suites do so if they have something to store there.
+    # Otherwise we would end up with a lot of empty folders.
+    state_dir = os.path.join(opts.state_folder, run_id)
+
+    BurninTests.state_dir = state_dir
+    BurninTests.run_id = run_id
 
     # Choose tests to run
     if opts.show_stale:

--- a/snf-tools/synnefo_tools/burnin/logger.py
+++ b/snf-tools/synnefo_tools/burnin/logger.py
@@ -33,7 +33,6 @@ corresponding line and closes the file.
 
 import os
 import sys
-import os.path
 import logging
 import datetime
 

--- a/snf-tools/synnefo_tools/burnin/snapshots.py
+++ b/snf-tools/synnefo_tools/burnin/snapshots.py
@@ -42,12 +42,7 @@ class SnapshotsTestSuite(CycladesTests):
         """Create a server and take a snapshot"""
         self.account = self._get_uuid()
         use_image = random.choice(self._parse_images())
-        archipelago_flavors = \
-            [f for f in self._parse_flavors() if
-             f['SNF:disk_template'].startswith('ext_archipelago')]
-        self.assertGreater(len(archipelago_flavors), 0,
-                           "No 'archipelago' disk template found")
-        self.use_flavor = random.choice(archipelago_flavors)
+        self.use_flavor = random.choice(self._parse_flavors())
         if self._image_is(use_image, "linux"):
             # Enforce personality test
             self.info("Creating personality content to be used")

--- a/snf-webproject/conf/gunicorn-hooks/gunicorn-stderr-logging.py
+++ b/snf-webproject/conf/gunicorn-hooks/gunicorn-stderr-logging.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -
+#
+# Copyright (C) 2016 GRNET S.A. and individual contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import logging
+
+
+def when_ready(server):
+    """Hook function to redirect stderr/stdout to logfile.
+
+    Hook function that is running when gunicorn server is ready and that is
+    responsible to set stdout and stderr to the file descriptor of the first
+    logging file handler.
+
+    FIXME: Handle logfile rotation.
+
+    """
+
+    server.log.info("Server ready, redirecting stdout/stderr to logfile")
+
+    # Use the already opened file of the first registered FileHandler
+    for h in server.log.error_log.handlers:
+        if isinstance(h, logging.FileHandler):
+            name = h.stream.name
+            fd = h.stream.fileno()
+
+            server.log.info("Redirecting stdout/stderr to %s (%s)", name, fd)
+
+            os.dup2(fd, 1)
+            os.dup2(fd, 2)
+
+            break
+    else:
+        server.log.warn("Could not find file handler!")
+
+    return


### PR DESCRIPTION
Hi,
This patch-set includes the following changes:
1) Purge mapfiles when deleting the corresponding versions in pithos
2) Some minor fixes in deploy
3) Support for out of tree test suites in burnin
4) Add another gunicorn example hook related to stderr logging
Note that these patches are on top of recent cstavr's commit (which is also included here).
Thanks,
dimara