### PR TITLE
Add API Endpoint Listing

### DIFF
--- a/snf-cyclades-app/synnefo/api/compute_urls.py
+++ b/snf-cyclades-app/synnefo/api/compute_urls.py
@@ -17,7 +17,7 @@ from django.conf.urls import include, patterns
 
 from snf_django.lib.api import api_endpoint_not_found
 from synnefo.api import (servers, flavors, images, extensions, keypairs)
-from synnefo.api.versions import versions_list, version_details
+from synnefo.api.compute_versions import versions_list, version_details
 
 
 #

--- a/snf-cyclades-app/synnefo/api/compute_versions.py
+++ b/snf-cyclades-app/synnefo/api/compute_versions.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2010-2016 GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from logging import getLogger
+
+from django.http import HttpResponse
+from django.template.loader import render_to_string
+import json
+from synnefo.cyclades_settings import COMPUTE_ROOT_URL
+from synnefo.api.util import build_version_object
+
+from snf_django.lib import api
+
+
+log = getLogger('synnefo.api')
+
+
+VERSIONS = [
+    build_version_object(COMPUTE_ROOT_URL, 2.0, 'v2.0', 'CURRENT',
+                         updated="2011-01-21T11:33:21-06:00"),
+]
+
+MEDIA_TYPES = [
+    {
+        "base": "application/xml",
+        "type": "application/vnd.openstack.compute.v2+xml"
+    },
+    {
+        "base": "application/json",
+        "type": "application/vnd.openstack.compute.v2+json"
+    }
+]
+
+DESCRIBED_BY = [
+    {
+        "rel": "describedby",
+        "type": "application/pdf",
+        "href": "http://docs.rackspacecloud.com/servers/api/v2/"
+                "cs-devguide-20110125.pdf"
+    },
+    {
+        "rel": "describedby",
+        "type": "application/vnd.sun.wadl+xml",
+        "href": "http://docs.rackspacecloud.com/servers/api/v2/"
+                "application.wadl"
+    }
+]
+
+
+@api.api_method(http_method='GET', user_required=True, logger=log)
+def versions_list(request):
+    # Normal Response Codes: 200, 203
+    # Error Response Codes: 400, 413, 500, 503
+
+    if request.serialization == 'xml':
+        data = render_to_string('versions_list.xml', {'versions': VERSIONS})
+    else:
+        data = json.dumps({'versions': VERSIONS})
+
+    return HttpResponse(data)
+
+
+@api.api_method('GET', user_required=True, logger=log)
+def version_details(request, api_version):
+    # Normal Response Codes: 200, 203
+    # Error Response Codes: computeFault (400, 500),
+    #                       serviceUnavailable (503),
+    #                       unauthorized (401),
+    #                       badRequest (400),
+    #                       overLimit(413)
+
+    log.debug('version_details %s', api_version)
+    # We hardcode to v2.0 since it is the only one we support
+    version = build_version_object(COMPUTE_ROOT_URL, 2.0, 'v2.0', 'CURRENT',
+                                   updated="2011-01-21T11:33:21-06:00",
+                                   media_types=MEDIA_TYPES)
+    version['links'] = version['links'] + DESCRIBED_BY
+
+    if request.serialization == 'xml':
+        data = render_to_string('version_details.xml', {'version': version})
+    else:
+        data = json.dumps({'version': version})
+    return HttpResponse(data)

--- a/snf-cyclades-app/synnefo/api/network_urls.py
+++ b/snf-cyclades-app/synnefo/api/network_urls.py
@@ -17,6 +17,7 @@ from django.conf.urls import include, patterns
 
 from snf_django.lib.api import api_endpoint_not_found
 from synnefo.api import (networks, ports, floating_ips, subnets)
+from synnefo.api.network_versions import versions_list, version_details
 
 
 network_api20_patterns = patterns(
@@ -29,6 +30,8 @@ network_api20_patterns = patterns(
 
 urlpatterns = patterns(
     '',
+    (r'^(?:.json|.xml|.atom)?$', versions_list),
+    (r'^v2.0/(?:.json|.xml|.atom)?$', version_details),
     (r'^v2.0/', include(network_api20_patterns)),
     (r'^.*', api_endpoint_not_found),
 )

--- a/snf-cyclades-app/synnefo/api/util.py
+++ b/snf-cyclades-app/synnefo/api/util.py
@@ -67,6 +67,26 @@ PITHOSMAP_PREFIX = "pithosmap://"
 log = getLogger('synnefo.api')
 
 
+def build_version_object(url, version_id, path, status, **extra_args):
+    """Generates a version object
+
+    The version object is structured based on the OpenStack
+    API. `extra_args` is for supporting extra information about
+    the version such as media types, extra links etc
+    """
+    base_version = {
+        'id': 'v%s' % version_id,
+        'status': status,
+        'links': [
+            {
+                'rel': 'self',
+                'href': '%s/%s/' % (url, path),
+            },
+        ],
+    }
+    return dict(base_version, **extra_args)
+
+
 def random_password():
     """Generates a random password
 

--- a/snf-cyclades-app/synnefo/cyclades_settings.py
+++ b/snf-cyclades-app/synnefo/cyclades_settings.py
@@ -48,7 +48,9 @@ ADMIN_PREFIX = cyclades_services['cyclades_admin']['prefix']
 VOLUME_PREFIX = cyclades_services['cyclades_volume']['prefix']
 
 COMPUTE_ROOT_URL = join_urls(BASE_URL, COMPUTE_PREFIX)
-
+NETWORK_ROOT_URL = join_urls(BASE_URL, NETWORK_PREFIX)
+BLOCKSTORAGE_ROOT_URL = join_urls(BASE_URL, VOLUME_PREFIX)
+IMAGE_ROOT_URL = join_urls(BASE_URL, PLANKTON_PREFIX)
 # --------------------------------------------------------------------
 # Process Astakos settings
 

--- a/snf-cyclades-app/synnefo/plankton/urls.py
+++ b/snf-cyclades-app/synnefo/plankton/urls.py
@@ -19,6 +19,7 @@ from django.http import HttpResponseNotAllowed
 from snf_django.lib.api import api_endpoint_not_found
 
 from synnefo.plankton import views
+from synnefo.plankton.versions import versions_list
 
 
 def demux(request):
@@ -73,6 +74,9 @@ image_v1_patterns = patterns(
 
 urlpatterns = patterns(
     '',
+    (r'^(?:.json)?$', versions_list),
+    (r'^versions', versions_list),
     (r'^v1.0/', include(image_v1_patterns)),
+    (r'^v1/', include(image_v1_patterns)),
     (r'^.*', api_endpoint_not_found),
 )

--- a/snf-cyclades-app/synnefo/plankton/versions.py
+++ b/snf-cyclades-app/synnefo/plankton/versions.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2010-2016 GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from logging import getLogger
+
+from django.http import HttpResponse
+import json
+
+from synnefo.cyclades_settings import IMAGE_ROOT_URL
+from synnefo.api.util import build_version_object
+
+from snf_django.lib import api
+
+
+log = getLogger('synnefo.api')
+
+MEDIA_TYPES = [
+    {
+        "base": "application/json",
+        "type": "application/vnd.openstack.compute.v2+json"
+    }
+]
+
+
+VERSIONS = [
+    build_version_object(IMAGE_ROOT_URL, 1.0, 'v1.0', 'CURRENT',
+                         media_types=MEDIA_TYPES),
+    build_version_object(IMAGE_ROOT_URL, 1, 'v1', 'CURRENT',
+                         media_types=MEDIA_TYPES),
+]
+
+
+@api.api_method(http_method='GET', user_required=True, logger=log)
+def versions_list(request):
+    # Normal Response Codes: 200, 203
+    # Error Response Codes: 400, 413, 500, 503
+
+    data = json.dumps({'versions': VERSIONS})
+    return HttpResponse(data)

--- a/snf-cyclades-app/synnefo/volume/urls.py
+++ b/snf-cyclades-app/synnefo/volume/urls.py
@@ -18,6 +18,7 @@ from django.conf.urls import patterns, include
 from django.http import HttpResponseNotAllowed
 from snf_django.lib import api
 from synnefo.volume import views, util
+from synnefo.volume.versions import versions_list
 from snf_django.lib.api import faults, utils
 
 
@@ -149,6 +150,8 @@ if settings.CYCLADES_SNAPSHOTS_ENABLED:
 
 urlpatterns = patterns(
     '',
+    (r'^(?:.json)?$', versions_list),
     (r'^v2.0/', include(volume_v2_patterns)),
-    (r'^.*', api.api_endpoint_not_found)
+    (r'^v2/', include(volume_v2_patterns)),
+    (r'^.*', api.api_endpoint_not_found),
 )

--- a/snf-cyclades-app/synnefo/volume/versions.py
+++ b/snf-cyclades-app/synnefo/volume/versions.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2010-2016 GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from logging import getLogger
+
+from django.http import HttpResponse
+import json
+from synnefo.cyclades_settings import BLOCKSTORAGE_ROOT_URL
+from synnefo.api.util import build_version_object
+
+from snf_django.lib import api
+
+
+log = getLogger('synnefo.api')
+
+
+MEDIA_TYPES = [
+    {
+        "base": "application/json",
+        "type": "application/vnd.openstack.compute.v2+json"
+    }
+]
+
+VERSIONS = [
+    build_version_object(BLOCKSTORAGE_ROOT_URL, 2.0, 'v2.0', 'CURRENT',
+                         min_version="2.0", version="2.0",
+                         media_types=MEDIA_TYPES),
+    build_version_object(BLOCKSTORAGE_ROOT_URL, 2, 'v2', 'CURRENT',
+                         min_version="2", version="2",
+                         media_types=MEDIA_TYPES)
+]
+
+
+@api.api_method(http_method='GET', user_required=True, logger=log)
+def versions_list(request):
+    # Normal Response Codes: 200, 203
+    # Error Response Codes: 400, 413, 500, 503
+
+    data = json.dumps({'versions': VERSIONS})
+    return HttpResponse(data)


### PR DESCRIPTION
Make the compute API is now explorable from the root of each service. The
responses are based on the ones that the OpenStack API produces. For
example, the Compute service of cyclades is explorable on

{host}/cyclades/compute/

This endpoint will list all the versions supported by Synnefo(only v2.0
in this example). Further exploring is possible by the supported version
number appended to the original root url.

{host}/cyclades/compute/{version}/

Depending on the service, this endpoint will return information such as
supported media types, links of microservices etc.