### PR TITLE
Add Server Create key_name

### DIFF
--- a/snf-cyclades-app/synnefo/api/servers.py
+++ b/snf-cyclades-app/synnefo/api/servers.py
@@ -231,7 +231,7 @@ def vm_to_dict(vm, detail=False):
             d['diagnostics'] = []
         # Fixed
         d["security_groups"] = [{"name": "default"}]
-        d["key_name"] = None
+        d["key_name"] = vm.key_name
         d["config_drive"] = ""
         d["accessIPv4"] = ""
         d["accessIPv6"] = ""
@@ -413,6 +413,7 @@ def create_server(request):
             assert isinstance(networks, list)
         project = server.get("project")
         shared_to_project=server.get("shared_to_project", False)
+        key_name = server.get('key_name')
     except (KeyError, AssertionError):
         raise faults.BadRequest("Malformed request")
 
@@ -439,7 +440,8 @@ def create_server(request):
                         metadata=metadata, personality=personality,
                         project=project, networks=networks, volumes=volumes,
                         shared_to_project=shared_to_project,
-                        user_projects=request.user_projects)
+                        user_projects=request.user_projects,
+                        key_name=key_name)
 
     log.info("User %s created VM %s, shared: %s", user_id, vm.id,
              shared_to_project)

--- a/snf-cyclades-app/synnefo/db/migrations/0004_virtualmachine_key_name.py
+++ b/snf-cyclades-app/synnefo/db/migrations/0004_virtualmachine_key_name.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('db', '0003_auto_ip_ownership'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='virtualmachine',
+            name='key_name',
+            field=models.CharField(max_length=100, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/snf-cyclades-app/synnefo/db/models.py
+++ b/snf-cyclades-app/synnefo/db/models.py
@@ -360,6 +360,7 @@ class VirtualMachine(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
     imageid = models.CharField(max_length=100, null=False)
+    key_name = models.CharField(max_length=100, null=True)
     image_version = models.IntegerField(null=True)
     hostid = models.CharField(max_length=100)
     flavor = models.ForeignKey(Flavor, on_delete=models.PROTECT)


### PR DESCRIPTION
Following the implemented endpoints for the keypairs, we 've added
functionality for the keypair injection onto the VM creation. Once a
user wants to create a new VM, he can provide a `key_name` which will be
used for obtaining a stored keypair. The contents of this keypair will
be injected to the new machine, using an extension in the ganeti client