### PR TITLE
Fix Compute os-floatingips endpoint

### DIFF
--- a/snf-cyclades-app/synnefo/api/compute_urls.py
+++ b/snf-cyclades-app/synnefo/api/compute_urls.py
@@ -16,9 +16,10 @@
 from django.conf.urls import include, patterns
 
 from snf_django.lib.api import api_endpoint_not_found
-from synnefo.api import (servers, flavors, images, extensions, keypairs)
-from synnefo.api.compute_versions import versions_list, version_details
 
+from synnefo.api import (servers, flavors, images, extensions, keypairs,
+                         floating_ips)
+from synnefo.api.compute_versions import versions_list, version_details
 
 #
 # The OpenStack Compute API v2.0
@@ -29,7 +30,8 @@ compute_api20_patterns = patterns(
     (r'^flavors', include(flavors)),
     (r'^images', include(images)),
     (r'^extensions', include(extensions)),
-    (r'^os-keypairs', include(keypairs))
+    (r'^os-keypairs', include(keypairs)),
+    (r'^os-floatingips', include(floating_ips))
 )
 
 

--- a/snf-cyclades-app/synnefo/api/floating_ips.py
+++ b/snf-cyclades-app/synnefo/api/floating_ips.py
@@ -41,7 +41,7 @@ pools_urlpatterns = patterns(
 )
 '''
 
-ips_urlpatterns = patterns(
+urlpatterns = patterns(
     'synnefo.api.floating_ips',
     (r'^(?:/|.json|.xml)?$', 'demux'),
     (r'^/detail(?:.json|.xml)?$', 'list_floating_ips', {'detail': True}),

--- a/snf-cyclades-app/synnefo/api/network_urls.py
+++ b/snf-cyclades-app/synnefo/api/network_urls.py
@@ -25,7 +25,7 @@ network_api20_patterns = patterns(
     (r'^networks', include(networks)),
     (r'^ports', include(ports)),
     (r'^subnets', include(subnets)),
-    (r'^floatingips', include(floating_ips.ips_urlpatterns)),
+    (r'^floatingips', include(floating_ips)),
 )
 
 urlpatterns = patterns(


### PR DESCRIPTION
In order to be compatible with some Open Stack clients such as Vagrant,
we added an os-floatingips to the Compute API. The calls on this
endpoint will be redirected to the respective networking endpoints.