### PR TITLE
[BUGFIX] Add URL regex validator on keypair name

### DIFF
--- a/snf-cyclades-app/synnefo/api/keypairs.py
+++ b/snf-cyclades-app/synnefo/api/keypairs.py
@@ -26,16 +26,20 @@ from snf_django.lib.api import utils, faults
 from synnefo.userdata.models import PublicKeyPair
 from synnefo.userdata.util import generate_keypair, SUPPORT_GENERATE_KEYS
 from synnefo.api import util
+from synnefo.api.validators import name_leading_trailing_spaces
 from synnefo.db import transaction
 
 from logging import getLogger
 
 log = getLogger(__name__)
 
+log.debug(name_leading_trailing_spaces)
+
 urlpatterns = patterns(
     'synnefo.api.keypairs',
     (r'^(?:/|.json|.xml)?$', 'demux'),
-    (r'^/([\w-]+)(?:/|.json|.xml)?$', 'keypair_demux'),
+    (r'^/(%(key_name_regex)s)(?:/|.json|.xml)?$' % {
+        'key_name_regex': name_leading_trailing_spaces}, 'keypair_demux'),
 )
 
 

--- a/snf-cyclades-app/synnefo/api/validators.py
+++ b/snf-cyclades-app/synnefo/api/validators.py
@@ -1,0 +1,71 @@
+# Copyright (C) 2010-2014 GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unicodedata
+import six
+import re
+
+
+def is_printable(c):
+    try:
+        c.encode('utf-8')
+        return True
+    except UnicodeEncodeError:
+        return False
+
+
+def build_regex_range(ws=True, exclude=None):
+
+    if exclude is None:
+        exclude = {}
+    else:
+        exclude = {k: None for k in exclude}
+
+    regex = ""
+    last = None
+    last_added = None
+    in_range = False
+
+    def is_valid(c):
+        if c in exclude:
+            return False
+        elif ws:
+            return is_printable(c)
+
+        return (is_printable(c) and unicodedata.category(c) != "Zs")
+
+    for c in range(0xFFFF):
+        c = six.unichr(c)
+        if is_valid(c):
+            if not in_range:
+                regex += re.escape(c)
+                last_added = c
+            in_range = True
+        else:
+            if in_range and last != last_added:
+                regex += "-" + re.escape(last)
+            in_range = False
+        last = c
+    else:
+        if in_range:
+            regex += "-" + re.escape(c)
+    return regex
+
+name_leading_trailing_spaces = (
+    "[%(ws)s]*[%(no_ws)s]+[%(ws)s]*|"
+    "[%(ws)s]*[%(no_ws)s][%(no_ws)s%(ws)s]+[%(no_ws)s][%(ws)s]*") % {
+        'ws': build_regex_range(),
+        'no_ws': build_regex_range(ws=False)
+    }


### PR DESCRIPTION
For the time being, Synnefo's API for keypairs (`/os-keypairs`)
supported only English characters(A-Z, a-z), numbers(0-9), dashes(-) and
underscores(_). That practice generated some compatibility issues, since
some clients such as Vagrant generate key names and append extra
characters such as colons(:), spaces( ) etc.

Using OpenStack's Nova implementation, we added a regex generator that
accepts a defined range of UTF-8 characters. We can use this validator
to further improve the validation and URL checking of various endpoints.

As a showcase we have implemented a leading trailing space validator for
the key names that accepts strings that contain at least one non
white space character.