### PR TITLE
cyclades: Add floating IPs endpoint on Compute API

### DIFF
--- a/snf-cyclades-app/synnefo/api/compute_urls.py
+++ b/snf-cyclades-app/synnefo/api/compute_urls.py
@@ -31,7 +31,7 @@ compute_api20_patterns = patterns(
     (r'^images', include(images)),
     (r'^extensions', include(extensions)),
     (r'^os-keypairs', include(keypairs)),
-    (r'^os-floating-ips', include(floating_ips))
+    (r'^os-floating-ips', include(floating_ips.compute_urlpatterns))
 )
 
 


### PR DESCRIPTION
Although in some latter versions of Compute, floating IPs endpoint is
not supported, there are some clients that utilize it and will fail in
any other case (e.g. Vagrant with Openstack driver). Previously in
synnefo, we were implementing this endpoint but the response was
not compliant to the Openstack specifications.

In that sense, we have slightly changed the api methods on
`api/floatingips.py` in order to be more modular. More specifically,
every api method that renders data, accepts a view parameter which is a
function that will format the data appropriately.