### PR TITLE
burnin: add ping6 check before trying to ssh

### DIFF
--- a/snf-tools/synnefo_tools/burnin/server_tests.py
+++ b/snf-tools/synnefo_tools/burnin/server_tests.py
@@ -222,7 +222,14 @@ class GeneratedServerTestSuite(CycladesTests):
         # The hostname must be of the form 'prefix-id'
         self.assertTrue(hostname.endswith("-%d" % self.server['id']))
 
-    def test_018_ssh_to_server_ipv6(self):
+    def test_018a_server_ping_ipv6(self):
+        """Test server responds to ping6 after reboot"""
+        self._skip_if(not self._image_is(self.use_image, "linux"),
+                      "only valid for Linux servers")
+        self._skip_if(not self.use_ipv6, "--no-ipv6 flag enabled")
+        self._insist_on_ping(self.ipv6[0], version=6)
+
+    def test_018b_ssh_to_server_ipv6(self):
         """Test SSH to server public IPv6 works, verify hostname"""
         self._skip_if(not self._image_is(self.use_image, "linux"),
                       "only valid for Linux servers")


### PR DESCRIPTION
As with test_017_ssh_to_server_ipv4 it makes sense to check IPv6
ping prior to initiating a IPv6 ssh connection.

There have been cases where host had not assigned the IPv6 address
after reboot, even if test_010_server_ping_ipv6 was successful.